### PR TITLE
railway: Nixpacks deploy config for backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,8 @@ SUPABASE_SERVICE_ROLE_KEY=
 
 # --- Mobile (EXPO_PUBLIC_ prefix is required so the Expo bundler exposes them) --
 
-# Backend base URL. Local dev: http://localhost:8000. Prod: Railway URL.
+# Backend base URL. Local dev: http://localhost:8000.
+# Prod: copy the public domain from Railway dashboard → your service → Settings → Networking → Public Domain.
 EXPO_PUBLIC_BACKEND_URL=http://localhost:8000
 
 # Picovoice Porcupine — https://console.picovoice.ai/

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS",
+    "buildCommand": "cd backend && uv sync --frozen"
+  },
+  "deploy": {
+    "startCommand": "cd backend && uv run uvicorn app.main:app --host 0.0.0.0 --port $PORT",
+    "healthcheckPath": "/healthz",
+    "healthcheckTimeout": 30,
+    "restartPolicyType": "ON_FAILURE",
+    "numReplicas": 1
+  }
+}


### PR DESCRIPTION
## What
Adds root-level `railway.json` (Nixpacks builder, `cd backend && uv sync` build, uvicorn with `$PORT` start, `/healthz` healthcheck) so the FastAPI stub can go live. Clarifies the `.env.example` comment for where `EXPO_PUBLIC_BACKEND_URL` comes from in prod.

## Why
Hour 0–2 deliverable per design doc §12 — slipped from hour-0 scope. Needed so mobile can hit a real backend once integration starts.

## How to test
1. Connect repo to Railway project → deploy from `rh/railway-deploy` (or merge and deploy from `main`).
2. `curl $RAILWAY_URL/healthz` → expect `{"status":"ok"}`.
3. Local smoke still green: `cd backend && uv run pytest tests/smoke/ -x`.

Note: the deployed instance cannot pass the smoke test end-to-end because `TestClient` dependency overrides don't apply on a real server and Gemini keys may not be set yet. `/healthz` is the deployment-success bar.

## Checklist
- [x] Smoke test green: `cd backend && uv run pytest tests/smoke/ -x`
- [x] No `.env` in diff; `.env.example` comment clarified only
- [x] API contract unchanged
- [x] Rebased on main (branched off `39c721a`)
- [x] No edits under `backend/gemini_client/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)