### PR TITLE
mobile: real web mic + real /utterance round-trip

### DIFF
--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,0 +1,3 @@
+EXPO_PUBLIC_BACKEND_URL=http://localhost:8000
+# Set to 1 to use mocked API responses and skip the real backend (UI-only work).
+EXPO_PUBLIC_MOCK=0

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,7 +1,8 @@
 import { StatusBar } from 'expo-status-bar';
-import { useEffect, useReducer, useState } from 'react';
+import { useEffect, useReducer, useRef, useState } from 'react';
 import { Pressable, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { createSession, IS_MOCK, sendUtterance } from './src/api/client';
+import { cancelRecording, startRecording, stopRecording } from './src/audio/recorder';
 import { initialState, reducer } from './src/state/machine';
 import type { Action, MachineState } from './src/state/machine';
 
@@ -25,8 +26,8 @@ function advanceActionFor(state: MachineState): Action | null {
 
 function advanceLabelFor(tag: MachineState['tag']): string {
   switch (tag) {
-    case 'Armed': return 'Simulate wake word';
-    case 'Listening': return 'Simulate silence (end utterance)';
+    case 'Armed': return 'Wake (tap to start recording)';
+    case 'Listening': return 'Stop recording';
     case 'Processing': return '…waiting for backend';
     case 'Speaking': return 'Simulate playback end';
     case 'Done': return 'Session finalized';
@@ -37,6 +38,8 @@ export default function App() {
   const [state, dispatch] = useReducer(reducer, initialState);
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [isBusy, setIsBusy] = useState(false);
+  const recordedBlobRef = useRef<Blob | null>(null);
 
   useEffect(() => {
     createSession('demo-user')
@@ -45,17 +48,58 @@ export default function App() {
   }, []);
 
   useEffect(() => {
+    if (state.tag !== 'Listening') return;
+    setError(null);
+    startRecording().catch((e: unknown) => {
+      const name = e instanceof Error ? e.name : '';
+      if (name === 'NotAllowedError') {
+        setError('Mic permission denied. Grant access and tap Wake again.');
+      } else if (name === 'NotFoundError') {
+        setError('No microphone found on this device.');
+      } else {
+        setError(`startRecording failed: ${String(e)}`);
+      }
+      dispatch({ type: 'MANUAL_STOP' });
+    });
+    return () => {
+      // Fires when state leaves Listening. If we transitioned via SILENCE_DETECTED
+      // the button handler already stopped the recorder; this is a no-op then.
+      cancelRecording().catch(() => {});
+    };
+  }, [state.tag]);
+
+  useEffect(() => {
     if (state.tag !== 'Processing' || !sessionId) return;
-    // TODO(rh/mic-vad): source this blob from src/audio/recorder.ts::stopRecording() when
-    // the real mic is wired. `Blob` is a web-only global; this path is MOCK-only today.
-    const blob = new Blob([], { type: 'audio/wav' });
+    const blob = recordedBlobRef.current ?? new Blob([], { type: 'audio/wav' });
+    recordedBlobRef.current = null;
     sendUtterance(sessionId, blob)
       .then((response) => dispatch({ type: 'BACKEND_RESPONDED', response }))
-      .catch((e) => setError(String(e)));
+      .catch((e) => {
+        setError(String(e));
+        dispatch({ type: 'MANUAL_STOP' });
+      });
   }, [state.tag, sessionId]);
 
   const action = advanceActionFor(state);
-  const canAdvance = action !== null && state.tag !== 'Done';
+  const canAdvance = action !== null && state.tag !== 'Done' && !isBusy;
+
+  async function onAdvance() {
+    if (!action) return;
+    if (state.tag === 'Listening') {
+      setIsBusy(true);
+      try {
+        recordedBlobRef.current = await stopRecording();
+        dispatch({ type: 'SILENCE_DETECTED' });
+      } catch (e) {
+        setError(`stopRecording failed: ${String(e)}`);
+        dispatch({ type: 'MANUAL_STOP' });
+      } finally {
+        setIsBusy(false);
+      }
+      return;
+    }
+    dispatch(action);
+  }
 
   return (
     <SafeAreaView style={styles.root}>
@@ -69,7 +113,7 @@ export default function App() {
 
         <Pressable
           accessibilityLabel="Advance state"
-          onPress={() => action && dispatch(action)}
+          onPress={onAdvance}
           disabled={!canAdvance}
           style={[styles.advanceBtn, !canAdvance && styles.advanceBtnDisabled]}
         >
@@ -108,10 +152,36 @@ export default function App() {
         </View>
 
         {state.context.lastResponse && (
-          <View style={styles.panel}>
-            <Text style={styles.panelTitle}>Last response</Text>
-            <Text style={styles.mono}>{JSON.stringify(state.context.lastResponse, null, 2)}</Text>
-          </View>
+          <>
+            <View style={styles.panel}>
+              <Text style={styles.panelTitle}>Intent</Text>
+              <Text style={styles.ingredient}>{state.context.lastResponse.intent}</Text>
+            </View>
+
+            {state.context.lastResponse.items && state.context.lastResponse.items.length > 0 && (
+              <View style={styles.panel}>
+                <Text style={styles.panelTitle}>Parsed items</Text>
+                {state.context.lastResponse.items.map((item, i) => (
+                  <Text key={`item-${i}`} style={styles.ingredient}>
+                    • {item.raw_phrase}
+                    {item.qty != null ? ` — ${item.qty}${item.unit ? ' ' + item.unit : ''}` : ''}
+                  </Text>
+                ))}
+              </View>
+            )}
+
+            {state.context.lastResponse.answer && (
+              <View style={styles.panel}>
+                <Text style={styles.panelTitle}>Answer</Text>
+                <Text style={styles.ingredient}>{state.context.lastResponse.answer}</Text>
+              </View>
+            )}
+
+            <View style={styles.panel}>
+              <Text style={styles.panelTitle}>Raw response</Text>
+              <Text style={styles.mono}>{JSON.stringify(state.context.lastResponse, null, 2)}</Text>
+            </View>
+          </>
         )}
 
         {error && <Text style={styles.error}>{error}</Text>}

--- a/mobile/src/api/__tests__/client.test.ts
+++ b/mobile/src/api/__tests__/client.test.ts
@@ -1,0 +1,68 @@
+describe('sendUtterance', () => {
+  const ORIGINAL_ENV = process.env;
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+    globalThis.fetch = realFetch;
+  });
+
+  it('POSTs multipart/form-data to /utterance with session_id + audio fields when MOCK is off', async () => {
+    process.env.EXPO_PUBLIC_MOCK = '0';
+    process.env.EXPO_PUBLIC_BACKEND_URL = 'http://backend.test';
+
+    const fakeResponse = {
+      intent: 'add_ingredient',
+      ack_audio_url: '/static/ack-stub.mp3',
+      items: [],
+      current_ingredients: [],
+    };
+    const fetchMock: jest.Mock = jest.fn(async () => ({
+      ok: true,
+      json: async () => fakeResponse,
+    }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { sendUtterance } = require('../client');
+    const audio = new Blob(['x'], { type: 'audio/webm' });
+    const result = await sendUtterance('session-123', audio);
+
+    expect(result).toEqual(fakeResponse);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const call = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [url, init] = call;
+    expect(url).toBe('http://backend.test/utterance');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBeInstanceOf(FormData);
+    const form = init.body as FormData;
+    expect(form.get('session_id')).toBe('session-123');
+    expect(form.get('audio')).toBeInstanceOf(Blob);
+  });
+
+  it('throws on non-2xx backend response', async () => {
+    process.env.EXPO_PUBLIC_MOCK = '0';
+    globalThis.fetch = jest.fn(async () => ({ ok: false, status: 500 })) as unknown as typeof fetch;
+
+    const { sendUtterance } = require('../client');
+    await expect(sendUtterance('s1', new Blob(['x']))).rejects.toThrow(/500/);
+  });
+
+  it('uses the mock implementation when EXPO_PUBLIC_MOCK=1', async () => {
+    process.env.EXPO_PUBLIC_MOCK = '1';
+    const fetchMock: jest.Mock = jest.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { sendUtterance, createSession } = require('../client');
+    await createSession('demo-user');
+    const response = await sendUtterance('s1', new Blob(['x']));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response).toHaveProperty('intent');
+    expect(response).toHaveProperty('current_ingredients');
+  });
+});

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -1,4 +1,3 @@
-import { Platform } from 'react-native';
 import type {
   CreateSessionRequest,
   CreateSessionResponse,
@@ -9,7 +8,7 @@ import type {
 import { mockCreateSession, mockFinalize, mockSendUtterance } from './mock';
 
 const BACKEND_URL = process.env.EXPO_PUBLIC_BACKEND_URL ?? 'http://localhost:8000';
-const MOCK = Platform.OS === 'web' || process.env.EXPO_PUBLIC_MOCK === '1';
+const MOCK = process.env.EXPO_PUBLIC_MOCK === '1';
 
 export async function createSession(userId: string): Promise<CreateSessionResponse> {
   const body: CreateSessionRequest = { user_id: userId };
@@ -29,10 +28,9 @@ export async function sendUtterance(sessionId: string, audio: Blob): Promise<Utt
 
   const form = new FormData();
   form.append('session_id', sessionId);
-  // TODO(rh/mic-vad): replace with RN FormData file shape `{ uri, name, type }` when the
-  // real recorder lands. This cast is unreachable on web (MOCK gate) but will produce an
-  // invalid multipart body on the dev client.
-  form.append('audio', audio as unknown as string);
+  // TODO(rh/phone-mic): RN FormData wants `{ uri, name, type }` not a Blob. This path
+  // works on web (MediaRecorder hands us a real Blob); phone wiring replaces it.
+  form.append('audio', audio, 'audio.wav');
   const res = await fetch(`${BACKEND_URL}/utterance`, { method: 'POST', body: form });
   if (!res.ok) throw new Error(`sendUtterance failed: ${res.status}`);
   return res.json();

--- a/mobile/src/audio/recorder.ts
+++ b/mobile/src/audio/recorder.ts
@@ -1,5 +1,6 @@
-// TODO(rh/mic-vad): wire expo-av Audio.Recording in a later branch.
-// See docs/design.md §4 (Listening state) and root CLAUDE.md architecture rule 1.
+// Native stub. The web implementation lives in recorder.web.ts; Metro resolves
+// that on web, this on native. Phone wiring (expo-av Audio.Recording) lands in rh/phone-mic.
+// See docs/design.md §4 and root CLAUDE.md architecture rule 1.
 
 export async function startRecording(): Promise<void> {
   return;
@@ -7,4 +8,8 @@ export async function startRecording(): Promise<void> {
 
 export async function stopRecording(): Promise<Blob> {
   return new Blob([], { type: 'audio/wav' });
+}
+
+export async function cancelRecording(): Promise<void> {
+  return;
 }

--- a/mobile/src/audio/recorder.web.ts
+++ b/mobile/src/audio/recorder.web.ts
@@ -1,0 +1,50 @@
+// Web MediaRecorder implementation. Metro picks this over recorder.ts on web.
+// Root CLAUDE.md rule 1: one audio consumer at a time — release the stream on stop/cancel.
+
+let mediaRecorder: MediaRecorder | null = null;
+let stream: MediaStream | null = null;
+let chunks: Blob[] = [];
+let stopPromise: Promise<Blob> | null = null;
+
+export async function startRecording(): Promise<void> {
+  if (mediaRecorder) throw new Error('already recording');
+  stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  chunks = [];
+  const recorder = new MediaRecorder(stream);
+  recorder.ondataavailable = (e) => {
+    if (e.data.size > 0) chunks.push(e.data);
+  };
+  stopPromise = new Promise<Blob>((resolve) => {
+    recorder.onstop = () => {
+      const mime = recorder.mimeType || 'audio/webm';
+      resolve(new Blob(chunks, { type: mime }));
+    };
+  });
+  mediaRecorder = recorder;
+  recorder.start();
+}
+
+export async function stopRecording(): Promise<Blob> {
+  if (!mediaRecorder || !stopPromise) throw new Error('not recording');
+  const recorder = mediaRecorder;
+  const pending = stopPromise;
+  recorder.stop();
+  const blob = await pending;
+  releaseStream();
+  return blob;
+}
+
+export async function cancelRecording(): Promise<void> {
+  if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+    mediaRecorder.stop();
+  }
+  releaseStream();
+}
+
+function releaseStream(): void {
+  stream?.getTracks().forEach((t) => t.stop());
+  mediaRecorder = null;
+  stream = null;
+  stopPromise = null;
+  chunks = [];
+}


### PR DESCRIPTION
## What

Wires real browser `MediaRecorder` capture and a real multipart POST to `/utterance` on web. First genuine end-to-end voice loop. Phone (expo-av), Porcupine, TTS playback, VAD, and summary screen are intentionally out of scope.

## Why

Mocked-on-web default (`Platform.OS === 'web' || EXPO_PUBLIC_MOCK === '1'`) kept us from ever exercising the real `/utterance` round-trip and masked a broken multipart cast in `sendUtterance`. Atharva's `gemini_client` (PR #3) is now ready to be driven by real audio; this PR closes that loop.

See design doc §4 (audio-consumer exclusivity), §7 (API contract).

## How to test

Backend running with `GROQ_API_KEY` exported. `EDAMAM_APP_ID/KEY` needed for `add_ingredient` utterances (the nutrition MCP tool fires inside gemini_client); without them a question-intent utterance ("how long should pasta boil?") is the safest smoke.

```bash
# terminal 1
cd backend
set -a && source ../.env && set +a
uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000

# terminal 2
cd mobile
npx expo start --web
```

Open http://localhost:8081. Subtitle should show `MOCK: off · session: <uuid>`. Tap **Wake** → grant mic permission → speak → tap **Stop recording**. Watch state advance Armed → Listening → Processing → Speaking; `Intent`, `Parsed items`, and `Answer` panels render the real `UtteranceResponse`.

Unit tests: `cd mobile && npm test` — 23/23 green (20 reducer + 3 new client tests covering real multipart + mock fallback). `npx tsc --noEmit` clean. code-reviewer subagent returned `pass`.

## Known follow-ups (out of scope)

- **Phone (`rh/phone-mic`):** `recorder.web.ts` handles web; `recorder.ts` is a native stub. Phone needs expo-av `Audio.Recording` + RN FormData `{ uri, name, type }` shape — noted in a TODO in `client.ts`.
- **STT mime hint:** MediaRecorder emits `audio/webm;codecs=opus` on Chromium, `audio/mp4` on Safari. Groq Whisper sniffs content so the backend's hardcoded `"audio.wav"` hint is cosmetic, but if demo testing surfaces misstranscription, ElevenLabs Scribe is a ~3-line swap inside `backend/gemini_client/client.py:95-99` (Atharva's file).
- **500s bypass CORS middleware.** When the backend throws (e.g. missing env var), the 500 response lacks `Access-Control-Allow-Origin` and the browser layers a CORS error on top of the real fault. Cosmetic — diagnose via `curl` or the backend terminal, not the browser error.

## Checklist

- [x] Tests added/updated and passing (`npm test` — 23/23)
- [ ] Smoke test green: `cd backend && uv run pytest tests/smoke/ -x` — not re-run this branch (backend untouched)
- [x] No `.env` in diff; `.env.example` added with `EXPO_PUBLIC_BACKEND_URL` + `EXPO_PUBLIC_MOCK`
- [x] API contract unchanged (`mobile/src/api/types.ts` untouched)
- [x] Rebased on `main` (not merged)
- [ ] `CLAUDE.md` updated — not needed, architecture unchanged
- [x] No edits under `backend/gemini_client/`