### PR TITLE
tts: wire ElevenLabs Turbo v2.5 streaming

### DIFF
--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -3,6 +3,7 @@ from functools import lru_cache
 from gemini_client import process_utterance
 
 from app.config import Settings
+from app.tts import ElevenLabsTTS
 
 
 @lru_cache
@@ -12,3 +13,8 @@ def get_settings() -> Settings:
 
 def get_gemini_client():
     return process_utterance
+
+
+@lru_cache
+def get_tts() -> ElevenLabsTTS:
+    return ElevenLabsTTS(get_settings())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.routes import finalize, recipes, sessions, utterance
+from app.routes import finalize, recipes, sessions, tts, utterance
 
 app = FastAPI(title="Sous Chef", version="0.1.0")
 
@@ -16,6 +16,7 @@ app.include_router(sessions.router, tags=["sessions"])
 app.include_router(utterance.router, tags=["utterance"])
 app.include_router(finalize.router, tags=["finalize"])
 app.include_router(recipes.router, tags=["recipes"])
+app.include_router(tts.router, tags=["tts"])
 
 
 @app.get("/healthz")

--- a/backend/app/routes/tts.py
+++ b/backend/app/routes/tts.py
@@ -1,0 +1,40 @@
+import httpx
+from elevenlabs.core.api_error import ApiError
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+
+from app.deps import get_tts
+from app.tts import ElevenLabsTTS
+
+router = APIRouter()
+
+
+@router.get("/tts/stream/{audio_id}")
+def tts_stream(
+    audio_id: str,
+    tts: ElevenLabsTTS = Depends(get_tts),
+) -> StreamingResponse:
+    text = tts.pop_text(audio_id)
+    if text is None:
+        raise HTTPException(status_code=404, detail="audio_expired")
+
+    stream_iter = iter(tts.synthesize_stream(text))
+    # Pull the first chunk up front so connection/auth errors surface as 504
+    # rather than a truncated MP3 after headers have flushed.
+    first_chunk: bytes | None = None
+    try:
+        for chunk in stream_iter:
+            if chunk:
+                first_chunk = chunk
+                break
+    except (ApiError, httpx.HTTPError) as e:
+        raise HTTPException(status_code=504, detail="tts_timeout") from e
+
+    def gen():
+        if first_chunk is not None:
+            yield first_chunk
+        for chunk in stream_iter:
+            if chunk:
+                yield chunk
+
+    return StreamingResponse(gen(), media_type="audio/mpeg")

--- a/backend/app/routes/utterance.py
+++ b/backend/app/routes/utterance.py
@@ -1,7 +1,14 @@
-from fastapi import APIRouter, Depends, File, Form, UploadFile
+import logging
 
-from app.deps import get_gemini_client
+from fastapi import APIRouter, Depends, File, Form, UploadFile
+from gemini_client import Intent
+from gemini_client import UtteranceResponse as GeminiUtteranceResponse
+
+from app.deps import get_gemini_client, get_tts
 from app.schemas.utterance import UtteranceResponse
+from app.tts import ElevenLabsTTS
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -11,12 +18,35 @@ async def process_utterance_endpoint(
     audio: UploadFile = File(...),
     session_id: str = Form(...),
     gemini=Depends(get_gemini_client),
+    tts: ElevenLabsTTS = Depends(get_tts),
 ) -> UtteranceResponse:
     audio_bytes = await audio.read()
-    result = await gemini(audio_bytes, [], None)
+
+    # TODO(ad/gemini-fix): gemini_client currently crashes on some Groq outputs
+    # (json.JSONDecodeError 'Extra data'). Catch + soft-fall so the demo loop stays
+    # alive end-to-end. Drop once docs/notes/2026-04-18-gemini-client-json-extra-data.md
+    # is resolved.
+    try:
+        result = await gemini(audio_bytes, [], None)
+    except Exception as e:
+        logger.warning("gemini_soft_fall: %s: %s", type(e).__name__, e)
+        result = GeminiUtteranceResponse(
+            intent=Intent.small_talk,
+            ack="Okay.",
+            items=None,
+            answer=None,
+        )
+
+    # Design §8: for a question intent the `answer` is the spoken reply;
+    # otherwise the `ack` is what the user hears. Fallback to a filler so we never
+    # send an empty string to ElevenLabs (which 400s).
+    picked = result.answer if result.intent == Intent.question and result.answer else result.ack
+    tts_text = (picked or "").strip() or "Okay."
+    audio_id = tts.stash_text(tts_text)
+
     return UtteranceResponse(
         intent=result.intent,
-        ack_audio_url="/static/ack-stub.mp3",
+        ack_audio_url=f"/tts/stream/{audio_id}",
         items=result.items,
         answer=result.answer,
         current_ingredients=result.items or [],

--- a/backend/app/tts.py
+++ b/backend/app/tts.py
@@ -1,5 +1,53 @@
-"""Stub TTS. Real impl will stream from ElevenLabs."""
+"""ElevenLabs Turbo v2.5 streaming TTS.
+
+The /utterance endpoint stashes the text it wants spoken and hands mobile a short
+audio id. /tts/stream/{id} pops the text and streams MP3 bytes back. Keeps the
+text off the URL (privacy) and avoids a round trip through the DB for a payload
+that is only relevant for ~2s.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from collections import OrderedDict
+from typing import Iterator
+
+from elevenlabs.client import ElevenLabs
+
+from app.config import Settings
+
+_STORE_CAP = 64
 
 
-def synthesize(text: str) -> str:
-    return "/static/ack-stub.mp3"
+class ElevenLabsTTS:
+    MODEL_ID = "eleven_turbo_v2_5"
+    OUTPUT_FORMAT = "mp3_22050_32"
+
+    def __init__(self, settings: Settings):
+        if not settings.elevenlabs_api_key or not settings.elevenlabs_voice_id:
+            raise RuntimeError("tts_not_configured")
+        self._voice_id = settings.elevenlabs_voice_id
+        self._client = ElevenLabs(api_key=settings.elevenlabs_api_key, timeout=30)
+        self._lock = threading.Lock()
+        self._store: OrderedDict[str, str] = OrderedDict()
+
+    def stash_text(self, text: str) -> str:
+        audio_id = uuid.uuid4().hex
+        with self._lock:
+            self._store[audio_id] = text
+            while len(self._store) > _STORE_CAP:
+                self._store.popitem(last=False)
+        return audio_id
+
+    def pop_text(self, audio_id: str) -> str | None:
+        with self._lock:
+            return self._store.pop(audio_id, None)
+
+    def synthesize_stream(self, text: str) -> Iterator[bytes]:
+        return self._client.text_to_speech.stream(
+            voice_id=self._voice_id,
+            text=text,
+            model_id=self.MODEL_ID,
+            output_format=self.OUTPUT_FORMAT,
+        )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Sous Chef backend — FastAPI"
 requires-python = ">=3.12"
 dependencies = [
+    "elevenlabs>=2.43.0",
     "fastapi>=0.136.0",
     "google-genai>=1.73.1",
     "groq>=1.2.0",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-from app.deps import get_gemini_client
+from app.deps import get_gemini_client, get_tts
 from app.main import app
 from gemini_client import Intent, ParsedIngredient, UtteranceResponse
 
@@ -46,9 +46,36 @@ async def _mock_process_utterance(
     )
 
 
+class _FakeTTS:
+    """Default test double — stash_text records the spoken text; no real network."""
+
+    def __init__(self) -> None:
+        self.last_stashed: str | None = None
+
+    def stash_text(self, text: str) -> str:
+        self.last_stashed = text
+        return "test-audio-id"
+
+    def pop_text(self, audio_id: str) -> str | None:
+        if audio_id != "test-audio-id":
+            return None
+        text = self.last_stashed
+        self.last_stashed = None
+        return text
+
+    def synthesize_stream(self, text: str):
+        yield b"\x00"
+
+
 @pytest.fixture
-def client():
+def fake_tts() -> _FakeTTS:
+    return _FakeTTS()
+
+
+@pytest.fixture
+def client(fake_tts: _FakeTTS):
     app.dependency_overrides[get_gemini_client] = lambda: _mock_process_utterance
+    app.dependency_overrides[get_tts] = lambda: fake_tts
     with TestClient(app) as c:
         yield c
     app.dependency_overrides.clear()

--- a/backend/tests/unit/test_tts.py
+++ b/backend/tests/unit/test_tts.py
@@ -1,0 +1,81 @@
+from elevenlabs.core.api_error import ApiError
+from fastapi.testclient import TestClient
+
+from app.deps import get_tts
+from app.main import app
+
+
+class _FakeTTS:
+    def __init__(self, chunks=None, raise_on_synth=None):
+        self._store: dict[str, str] = {}
+        self._chunks = chunks if chunks is not None else [b"ID3", b"\x00\x00ok"]
+        self._raise_on_synth = raise_on_synth
+        self.synth_text: str | None = None
+
+    def stash_text(self, text: str) -> str:
+        self._store["fixed-id"] = text
+        return "fixed-id"
+
+    def pop_text(self, audio_id: str) -> str | None:
+        return self._store.pop(audio_id, None)
+
+    def synthesize_stream(self, text: str):
+        self.synth_text = text
+        if self._raise_on_synth is not None:
+            raise self._raise_on_synth
+        yield from self._chunks
+
+
+def _with_tts(fake: _FakeTTS):
+    app.dependency_overrides[get_tts] = lambda: fake
+    return TestClient(app)
+
+
+def test_stream_happy_path_returns_audio_mpeg():
+    fake = _FakeTTS(chunks=[b"first-chunk", b"second-chunk"])
+    fake.stash_text("hello there")
+    try:
+        with _with_tts(fake) as c:
+            r = c.get("/tts/stream/fixed-id")
+        assert r.status_code == 200
+        assert r.headers["content-type"].startswith("audio/mpeg")
+        assert r.content == b"first-chunksecond-chunk"
+        assert fake.synth_text == "hello there"
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_stream_404_on_missing_id():
+    fake = _FakeTTS()
+    try:
+        with _with_tts(fake) as c:
+            r = c.get("/tts/stream/nonexistent")
+        assert r.status_code == 404
+        assert r.json() == {"detail": "audio_expired"}
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_stream_504_on_elevenlabs_api_error():
+    fake = _FakeTTS(raise_on_synth=ApiError(status_code=502, body={"error": "upstream"}))
+    fake.stash_text("hi")
+    try:
+        with _with_tts(fake) as c:
+            r = c.get("/tts/stream/fixed-id")
+        assert r.status_code == 504
+        assert r.json() == {"detail": "tts_timeout"}
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_pop_text_is_single_use():
+    fake = _FakeTTS()
+    fake.stash_text("once")
+    try:
+        with _with_tts(fake) as c:
+            r1 = c.get("/tts/stream/fixed-id")
+            r2 = c.get("/tts/stream/fixed-id")
+        assert r1.status_code == 200
+        assert r2.status_code == 404
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/unit/test_utterance.py
+++ b/backend/tests/unit/test_utterance.py
@@ -1,0 +1,153 @@
+import io
+import wave
+
+from fastapi.testclient import TestClient
+
+from app.deps import get_gemini_client, get_tts
+from app.main import app
+from gemini_client import Intent, ParsedIngredient, UtteranceResponse
+
+
+def _silence_bytes() -> bytes:
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(16000)
+        w.writeframes(b"\x00\x00" * 1000)
+    return buf.getvalue()
+
+
+class _FakeTTS:
+    def __init__(self) -> None:
+        self.last_stashed: str | None = None
+
+    def stash_text(self, text: str) -> str:
+        self.last_stashed = text
+        return "fake-id-xyz"
+
+    def pop_text(self, audio_id: str) -> str | None:
+        return None
+
+    def synthesize_stream(self, text: str):
+        yield b""
+
+
+def _post_utterance(c: TestClient) -> dict:
+    r = c.post(
+        "/utterance",
+        data={"session_id": "test-session"},
+        files={"audio": ("a.wav", _silence_bytes(), "audio/wav")},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_utterance_add_ingredient_stashes_ack():
+    fake_tts = _FakeTTS()
+
+    async def mock_gemini(*_args, **_kwargs):
+        return UtteranceResponse(
+            intent=Intent.add_ingredient,
+            ack="Got it, olive oil.",
+            items=[ParsedIngredient(name="olive oil", qty=1, unit="tsp", raw_phrase="olive oil")],
+        )
+
+    app.dependency_overrides[get_gemini_client] = lambda: mock_gemini
+    app.dependency_overrides[get_tts] = lambda: fake_tts
+    try:
+        with TestClient(app) as c:
+            body = _post_utterance(c)
+        assert body["intent"] == "add_ingredient"
+        assert body["ack_audio_url"] == "/tts/stream/fake-id-xyz"
+        assert fake_tts.last_stashed == "Got it, olive oil."
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_utterance_question_intent_stashes_answer_not_ack():
+    fake_tts = _FakeTTS()
+
+    async def mock_gemini(*_args, **_kwargs):
+        return UtteranceResponse(
+            intent=Intent.question,
+            ack="Sure.",
+            items=None,
+            answer="About 12 minutes at medium heat.",
+        )
+
+    app.dependency_overrides[get_gemini_client] = lambda: mock_gemini
+    app.dependency_overrides[get_tts] = lambda: fake_tts
+    try:
+        with TestClient(app) as c:
+            body = _post_utterance(c)
+        assert body["intent"] == "question"
+        assert body["answer"] == "About 12 minutes at medium heat."
+        assert fake_tts.last_stashed == "About 12 minutes at medium heat."
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_utterance_question_intent_with_null_answer_falls_back_to_ack():
+    fake_tts = _FakeTTS()
+
+    async def mock_gemini(*_args, **_kwargs):
+        return UtteranceResponse(
+            intent=Intent.question,
+            ack="I didn't catch that.",
+            items=None,
+            answer=None,
+        )
+
+    app.dependency_overrides[get_gemini_client] = lambda: mock_gemini
+    app.dependency_overrides[get_tts] = lambda: fake_tts
+    try:
+        with TestClient(app) as c:
+            body = _post_utterance(c)
+        assert body["ack_audio_url"].startswith("/tts/stream/")
+        assert fake_tts.last_stashed == "I didn't catch that."
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_utterance_gemini_raises_soft_falls_to_okay():
+    """Until Atharva's gemini_client JSON-parse bug is fixed, /utterance must keep
+    the demo loop alive rather than leaking a 500."""
+    fake_tts = _FakeTTS()
+
+    async def broken_gemini(*_args, **_kwargs):
+        raise ValueError("Extra data: line 1 column 112 (char 111)")
+
+    app.dependency_overrides[get_gemini_client] = lambda: broken_gemini
+    app.dependency_overrides[get_tts] = lambda: fake_tts
+    try:
+        with TestClient(app) as c:
+            body = _post_utterance(c)
+        assert body["intent"] == "small_talk"
+        assert body["ack_audio_url"].startswith("/tts/stream/")
+        assert fake_tts.last_stashed == "Okay."
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_utterance_empty_ack_and_null_answer_falls_back_to_filler():
+    """Until gemini_client reliably populates ack, empty text should not 400 ElevenLabs."""
+    fake_tts = _FakeTTS()
+
+    async def mock_gemini(*_args, **_kwargs):
+        return UtteranceResponse(
+            intent=Intent.add_ingredient,
+            ack="   ",
+            items=None,
+            answer=None,
+        )
+
+    app.dependency_overrides[get_gemini_client] = lambda: mock_gemini
+    app.dependency_overrides[get_tts] = lambda: fake_tts
+    try:
+        with TestClient(app) as c:
+            body = _post_utterance(c)
+        assert body["ack_audio_url"].startswith("/tts/stream/")
+        assert fake_tts.last_stashed == "Okay."
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -265,6 +265,23 @@ wheels = [
 ]
 
 [[package]]
+name = "elevenlabs"
+version = "2.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/7f/35dd0389c4a1cfe410b0adac60de4dfca563e504dcb788d027e308961864/elevenlabs-2.43.0.tar.gz", hash = "sha256:17e6c0ba632b5f8aa49001c2f0aac839fd3be8feb13a32ba00239713d3519775", size = 542311, upload-time = "2026-04-13T10:53:56.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/9a/6bd4322645b584377d402600e9282860767c689aaad83df11673222b93f9/elevenlabs-2.43.0-py3-none-any.whl", hash = "sha256:e03ea06d7f3086e8acf240823d15b81c718faee0e8ee6943eb639afe27b74e85", size = 1484376, upload-time = "2026-04-13T10:53:54.771Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.0"
 source = { registry = "https://pypi.org/simple" }
@@ -889,6 +906,7 @@ name = "sous-chef-backend"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "elevenlabs" },
     { name = "fastapi" },
     { name = "google-genai" },
     { name = "groq" },
@@ -910,6 +928,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "elevenlabs", specifier = ">=2.43.0" },
     { name = "fastapi", specifier = ">=0.136.0" },
     { name = "google-genai", specifier = ">=1.73.1" },
     { name = "groq", specifier = ">=1.2.0" },

--- a/docs/notes/2026-04-18-gemini-client-json-extra-data.md
+++ b/docs/notes/2026-04-18-gemini-client-json-extra-data.md
@@ -1,0 +1,62 @@
+# gemini_client — JSONDecodeError: Extra data on live Groq output
+
+**Date:** 2026-04-18
+**Owner:** Atharva (`backend/gemini_client/`)
+**Filed by:** Rishi (from `rh/elevenlabs-tts` integration)
+**Severity:** Blocker for mobile E2E (any real mic input hits this)
+
+## Symptom
+
+`POST /utterance` with a real audio file (non-silence) 500s with:
+
+```
+File ".../backend/gemini_client/client.py", line 149, in process_utterance
+    return UtteranceResponse.model_validate(json.loads(raw))
+                                            ^^^^^^^^^^^^^^^
+File ".../json/decoder.py", line 341, in decode
+    raise JSONDecodeError("Extra data", s, end)
+json.decoder.JSONDecodeError: Extra data: line 1 column 112 (char 111)
+```
+
+## Root cause hypothesis
+
+Groq's `llama-3.1-8b-instant` is emitting content after the intended JSON object —
+likely a second object, a prose explanation, or a trailing `</s>` token. `json.loads`
+rejects anything beyond a single top-level value, so the whole call fails even
+though the first 111 characters probably are a valid `UtteranceResponse`.
+
+## Suggested fix (non-exhaustive)
+
+One of:
+
+1. **Stricter prompt** — re-emphasise "return ONLY the JSON object, no prose, no code fences". Cheapest.
+2. **Greedy-object parse** — use `json.JSONDecoder.raw_decode(raw)` instead of
+   `json.loads(raw)`; it returns `(obj, end_index)` and ignores trailing junk. One line.
+3. **Structured output mode** — if Groq supports `response_format={"type": "json_object"}`
+   for llama-3.1-8b-instant, turn it on. Most robust.
+
+Option 2 is the smallest-diff unblock and would also handle the case where the
+model later appends a `</s>` or newline.
+
+## Cross-branch workaround (Rishi side)
+
+`backend/app/routes/utterance.py` (this PR, `rh/elevenlabs-tts`) now catches any
+exception from `gemini(...)`, logs a WARNING, and soft-falls to
+`intent=small_talk, ack="Okay."` so the voice loop demos end-to-end while the
+gemini_client bug is live. See the `TODO(ad/gemini-fix)` comment — remove both
+the try/except AND its test once this note's fix lands.
+
+## How to reproduce
+
+```bash
+cd backend && uv run uvicorn app.main:app --reload
+# POST /utterance at /docs with any real-speech m4a/wav (silence won't repro —
+# on silence Groq returns "" and the empty-ack fallback masks this bug)
+```
+
+## Files of interest
+
+- `backend/gemini_client/client.py:149` — the `json.loads(raw)` call
+- `backend/app/routes/utterance.py` — current soft-fall workaround
+- `backend/tests/unit/test_utterance.py::test_utterance_gemini_raises_soft_falls_to_okay`
+  — test that locks in the workaround behavior until the note is resolved

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -3,8 +3,13 @@ import { useEffect, useReducer, useRef, useState } from 'react';
 import { Pressable, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { createSession, IS_MOCK, sendUtterance } from './src/api/client';
 import { cancelRecording, startRecording, stopRecording } from './src/audio/recorder';
+import { playAck, stopAck } from './src/audio/tts';
 import { initialState, reducer } from './src/state/machine';
 import type { Action, MachineState } from './src/state/machine';
+
+const BACKEND_URL = process.env.EXPO_PUBLIC_BACKEND_URL ?? 'http://localhost:8000';
+// Design doc §4 rule 1: after TTS playback ends, wait before re-arming Porcupine.
+const PLAYBACK_REARM_MS = 300;
 
 const TAG_COLORS: Record<MachineState['tag'], string> = {
   Armed: '#1e88e5',
@@ -79,6 +84,34 @@ export default function App() {
         dispatch({ type: 'MANUAL_STOP' });
       });
   }, [state.tag, sessionId]);
+
+  useEffect(() => {
+    if (state.tag !== 'Speaking') return;
+    const url = state.context.lastResponse?.ack_audio_url;
+    if (!url) {
+      dispatch({ type: 'PLAYBACK_ENDED' });
+      return;
+    }
+    const fullUrl = url.startsWith('/') ? `${BACKEND_URL}${url}` : url;
+    let cancelled = false;
+    let rearmTimer: ReturnType<typeof setTimeout> | null = null;
+
+    playAck(fullUrl)
+      .catch((e: unknown) => {
+        // Swallow and still advance — a playback failure must not wedge the machine.
+        setError(`Playback failed: ${String(e)}`);
+      })
+      .then(() => {
+        if (cancelled) return;
+        rearmTimer = setTimeout(() => dispatch({ type: 'PLAYBACK_ENDED' }), PLAYBACK_REARM_MS);
+      });
+
+    return () => {
+      cancelled = true;
+      if (rearmTimer) clearTimeout(rearmTimer);
+      stopAck();
+    };
+  }, [state.tag, state.context.lastResponse]);
 
   const action = advanceActionFor(state);
   const canAdvance = action !== null && state.tag !== 'Done' && !isBusy;

--- a/mobile/src/audio/__tests__/tts.test.ts
+++ b/mobile/src/audio/__tests__/tts.test.ts
@@ -1,0 +1,84 @@
+describe('playAck / stopAck', () => {
+  const realAudio = (globalThis as any).Audio;
+
+  type Listener = () => void;
+
+  function makeAudioMock() {
+    const listeners: Record<string, Listener[]> = { ended: [], error: [] };
+    const instance = {
+      src: '',
+      play: jest.fn(() => Promise.resolve()),
+      pause: jest.fn(),
+      addEventListener: jest.fn((ev: string, cb: Listener) => {
+        listeners[ev] ??= [];
+        listeners[ev].push(cb);
+      }),
+      removeEventListener: jest.fn((ev: string, cb: Listener) => {
+        listeners[ev] = (listeners[ev] ?? []).filter((l) => l !== cb);
+      }),
+      fire(ev: 'ended' | 'error') {
+        for (const l of listeners[ev] ?? []) l();
+      },
+    };
+    return instance;
+  }
+
+  let lastInstance: ReturnType<typeof makeAudioMock> | null = null;
+
+  beforeEach(() => {
+    jest.resetModules();
+    lastInstance = null;
+    (globalThis as any).Audio = jest.fn(function AudioCtor(this: any) {
+      lastInstance = makeAudioMock();
+      return lastInstance as unknown as HTMLAudioElement;
+    });
+  });
+
+  afterEach(() => {
+    (globalThis as any).Audio = realAudio;
+  });
+
+  it('resolves when the audio element fires `ended`', async () => {
+    const { playAck } = require('../tts');
+    const p = playAck('http://backend.test/tts/stream/abc');
+    // The mock is constructed synchronously inside playAck.
+    expect(lastInstance).not.toBeNull();
+    expect(lastInstance!.src).toBe('http://backend.test/tts/stream/abc');
+    expect(lastInstance!.play).toHaveBeenCalledTimes(1);
+
+    lastInstance!.fire('ended');
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  it('rejects (without hanging) when the audio element fires `error`', async () => {
+    const { playAck } = require('../tts');
+    const p = playAck('http://backend.test/tts/stream/abc');
+    lastInstance!.fire('error');
+    await expect(p).rejects.toThrow(/playback failed/);
+  });
+
+  it('rejects when audio.play() itself rejects (autoplay policy)', async () => {
+    (globalThis as any).Audio = jest.fn(function AudioCtor(this: any) {
+      const inst = makeAudioMock();
+      inst.play = jest.fn(() => Promise.reject(new Error('NotAllowedError')));
+      lastInstance = inst;
+      return inst as unknown as HTMLAudioElement;
+    });
+
+    const { playAck } = require('../tts');
+    await expect(playAck('http://x')).rejects.toThrow(/NotAllowedError/);
+  });
+
+  it('stopAck resolves an in-flight playAck (used for MANUAL_STOP)', async () => {
+    const { playAck, stopAck } = require('../tts');
+    const p = playAck('http://backend.test/tts/stream/abc');
+    stopAck();
+    await expect(p).resolves.toBeUndefined();
+    expect(lastInstance!.pause).toHaveBeenCalled();
+  });
+
+  it('stopAck before any playAck is a no-op', () => {
+    const { stopAck } = require('../tts');
+    expect(() => stopAck()).not.toThrow();
+  });
+});

--- a/mobile/src/audio/tts.ts
+++ b/mobile/src/audio/tts.ts
@@ -1,8 +1,69 @@
-// TODO(rh/tts): replace with expo-av Sound.createAsync when integrating ElevenLabs.
-// Backend returns `ack_audio_url` — on phone, fetch + play. On web/mock, simulate playback.
+// Web-only playback this branch. Native path stays stubbed — phone work replaces it
+// with expo-av Sound.createAsync in a later branch.
+// Caller resolves relative URLs (e.g. "/tts/stream/<id>") against the backend base.
 
-export function playAck(_url: string): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, 500);
+type Disposable = { resolve: () => void; dispose: () => void };
+
+let currentControl: Disposable | null = null;
+
+function isWeb(): boolean {
+  return typeof globalThis !== 'undefined' && typeof (globalThis as any).Audio === 'function';
+}
+
+export function playAck(url: string): Promise<void> {
+  if (!isWeb()) {
+    return new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  // Preempt any prior playback so the state machine never doubles up.
+  stopAck();
+
+  return new Promise<void>((resolve, reject) => {
+    const AudioCtor = (globalThis as any).Audio as { new (): HTMLAudioElement };
+    const audio = new AudioCtor();
+
+    const dispose = () => {
+      audio.removeEventListener('ended', onEnded);
+      audio.removeEventListener('error', onError);
+      try {
+        audio.pause();
+        audio.src = '';
+      } catch {
+        // ignore — the element may already be detached
+      }
+    };
+    const onEnded = () => {
+      if (currentControl === control) currentControl = null;
+      dispose();
+      resolve();
+    };
+    const onError = () => {
+      if (currentControl === control) currentControl = null;
+      dispose();
+      reject(new Error('playback failed'));
+    };
+
+    const control: Disposable = { resolve, dispose };
+    currentControl = control;
+
+    audio.addEventListener('ended', onEnded);
+    audio.addEventListener('error', onError);
+    audio.src = url;
+    const p = audio.play();
+    if (p && typeof (p as Promise<void>).catch === 'function') {
+      (p as Promise<void>).catch((e: unknown) => {
+        if (currentControl === control) currentControl = null;
+        dispose();
+        reject(e instanceof Error ? e : new Error(String(e)));
+      });
+    }
   });
+}
+
+export function stopAck(): void {
+  const c = currentControl;
+  if (!c) return;
+  currentControl = null;
+  c.dispose();
+  c.resolve();
 }


### PR DESCRIPTION
## What

Replaces the hardcoded `/static/ack-stub.mp3` stub with real ElevenLabs Turbo v2.5 streaming TTS. Closes the voice loop: mic → Groq → ElevenLabs → speakers (web path).

## Why

Design §14 failure mode #1 (use ElevenLabs streaming) and §M4 DoD (TTS renders the spoken reply). Also: the stub path returned a URL that was never served — any mobile fetch would 404 silently.

Scope decisions made before coding:
- **Streaming endpoint** over save-and-serve — saves ~1s perceived latency, SDK helper makes it one generator.
- **For `intent == question`** we synthesize `answer`; else `ack`. One audio URL.
- **Web-only mobile playback** this branch. Native path stays stubbed until the phone lane lands.

## How to test

**Local**
```bash
cd backend && uv run uvicorn app.main:app --reload
cd mobile && npx expo start  # press w → browser → grant mic
```
Tap Wake → speak → Stop → hear TTS → state returns to Armed ~300ms later.

**Swagger isolation**
POST `/utterance` at `/docs`, copy the `ack_audio_url` from the response, open `http://localhost:8000<that_url>` in a new tab → MP3 plays directly.

**Tests**
- Backend: 11 pytests (4 TTS unit + 5 utterance unit + 2 smoke) — all green.
- Mobile: 28 Jest tests (5 new for `playAck`/`stopAck`) — all green.
- `tsc --noEmit` clean.

## Dependencies

- Backend: `elevenlabs` 2.43.0 (added via `uv add`, pinned in `uv.lock`).
- Railway: `ELEVENLABS_API_KEY` + `ELEVENLABS_VOICE_ID` already set via `railway variables --set-from-stdin --skip-deploys`; next deploy picks them up.

## Known workaround

`/utterance` soft-falls to `"Okay."` when `gemini_client` throws — covers the live `JSONDecodeError: Extra data` bug (see [docs/notes/2026-04-18-gemini-client-json-extra-data.md](docs/notes/2026-04-18-gemini-client-json-extra-data.md)). Remove the try/except + its test (`test_utterance_gemini_raises_soft_falls_to_okay`) once Atharva's fix is merged.

## Checklist

- [x] Tests added/updated and passing (11 backend + 28 mobile)
- [x] Smoke test green
- [x] No `.env` in diff; `.env.example` already had the keys
- [x] API contract unchanged (integration-checker: consistent)
- [x] Rebased on `main` (branch cut from origin/main today)
- [ ] `CLAUDE.md` updated if architecture changed — N/A, no architecture change
- [x] No edits under `backend/gemini_client/`