### PR TITLE
mobile: Porcupine wake-word + metering-VAD auto-stop (rh/wake-word)

### DIFF
--- a/docs/notes/2026-04-18-gemini-client-test-utterances-fail.md
+++ b/docs/notes/2026-04-18-gemini-client-test-utterances-fail.md
@@ -1,0 +1,26 @@
+# gemini_client / test_utterances flake observed during rh/wake-word verification
+
+**Date:** 2026-04-18
+**Branch where observed:** `rh/wake-word` (also reproduces on clean `main`).
+**Test:** `backend/tests/unit/test_utterances.py::test_simple_ingredient_with_qty`
+
+## Observation
+
+While running `cd backend && uv run pytest -x` to verify the `rh/wake-word` PR, the first failing test was `test_simple_ingredient_with_qty`. Stashed the wake-word changes, switched to `main`, re-ran the same single test — same failure. So this is **pre-existing on main**, not caused by `rh/wake-word`.
+
+The test calls Groq live (HTTP 200 returned) and then asserts on the parsed response. The assertion error itself wasn't captured in the run because `-x` aborted at the first failing test before stderr-on-failure output finished.
+
+## Why I didn't dig further
+
+- `gemini_client/` is Atharva's domain (root CLAUDE.md ownership rule).
+- The failure was not introduced by my PR.
+- The smoke test (`tests/smoke/`) — the one in Rishi's DoD — passes 2/2.
+- `tests/unit/test_utterances.py` is the live-Groq harness; could be a transient model-output drift or a prompt change interacting badly with a fixture.
+
+## What Atharva should look at
+
+- Run `uv run pytest tests/unit/test_utterances.py::test_simple_ingredient_with_qty -v` and capture the full assertion diff.
+- Likely candidates: model returned `unit="cloves"` (plural) instead of `"clove"` (singular per the system prompt), or `qty=2` returned as `2.0` vs `2` and the assertion is type-strict.
+- If it's a model-output drift, this is the kind of thing the prompt-tuning loop should catch — consider making the unit-strictness assertion a normalised compare (`unit.rstrip('s')`) or moving to a tolerance-based JSON-schema check.
+
+No GitHub issue opened yet — leaving that to Atharva once he's looked at the actual diff, since it might just be a flake.

--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,3 +1,7 @@
 EXPO_PUBLIC_BACKEND_URL=http://localhost:8000
 # Set to 1 to use mocked API responses and skip the real backend (UI-only work).
 EXPO_PUBLIC_MOCK=0
+# Picovoice Console access key for Porcupine wake-word detection.
+# Rate-limiter key, not a high-value secret — but still .env-only, never committed.
+# Get one at https://console.picovoice.ai/. EAS dev builds inherit via `eas env:create --environment development`.
+EXPO_PUBLIC_PICOVOICE_ACCESS_KEY=

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -2,8 +2,12 @@ import { StatusBar } from 'expo-status-bar';
 import { useEffect, useReducer, useRef, useState } from 'react';
 import { Pressable, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { createSession, IS_MOCK, sendUtterance } from './src/api/client';
+import { playDing } from './src/audio/ding';
+import { armPorcupine, disarmPorcupine } from './src/audio/porcupine';
 import { cancelRecording, startRecording, stopRecording } from './src/audio/recorder';
 import { playAck, stopAck } from './src/audio/tts';
+import type { MeterReading } from './src/audio/vad';
+import { shouldStop } from './src/audio/vad';
 import type { RecordedAudio } from './src/audio/types';
 import { initialState, reducer } from './src/state/machine';
 import type { Action, MachineState } from './src/state/machine';
@@ -13,6 +17,8 @@ const BACKEND_URL = process.env.EXPO_PUBLIC_BACKEND_URL ?? 'http://localhost:800
 const DEMO_USER_ID = '00000000-0000-0000-0000-000000000001';
 // Design doc §4 rule 1: after TTS playback ends, wait before re-arming Porcupine.
 const PLAYBACK_REARM_MS = 300;
+// Hard cap on a single listening window — defense against a missed VAD trigger.
+const MAX_LISTEN_MS = 10_000;
 
 const TAG_COLORS: Record<MachineState['tag'], string> = {
   Armed: '#1e88e5',
@@ -55,23 +61,84 @@ export default function App() {
       .catch((e) => setError(String(e)));
   }, []);
 
+  // Arm Porcupine whenever the session is live and we're back in Armed.
+  // Cleanup on transition out of Armed (and on unmount) releases the mic so
+  // expo-av can take it — root CLAUDE.md rule 1: only one audio consumer.
+  useEffect(() => {
+    if (state.tag !== 'Armed' || !sessionId) return;
+    let cancelled = false;
+    armPorcupine(() => {
+      if (cancelled) return;
+      dispatch({ type: 'WAKE_DETECTED' });
+    }).catch((e: unknown) => {
+      // Porcupine init failure should not wedge — manual Wake button still works.
+      setError(`armPorcupine failed: ${String(e)}`);
+    });
+    return () => {
+      cancelled = true;
+      disarmPorcupine().catch(() => {});
+    };
+  }, [state.tag, sessionId]);
+
   useEffect(() => {
     if (state.tag !== 'Listening') return;
     setError(null);
-    startRecording().catch((e: unknown) => {
-      const name = e instanceof Error ? e.name : '';
-      if (name === 'NotAllowedError') {
-        setError('Mic permission denied. Grant access and tap Wake again.');
-      } else if (name === 'NotFoundError') {
-        setError('No microphone found on this device.');
-      } else {
-        setError(`startRecording failed: ${String(e)}`);
+    let cancelled = false;
+    let hardCapTimer: ReturnType<typeof setTimeout> | null = null;
+    let stopping = false;
+    const readings: MeterReading[] = [];
+
+    const autoStop = async () => {
+      if (cancelled || stopping) return;
+      stopping = true;
+      if (hardCapTimer) clearTimeout(hardCapTimer);
+      try {
+        recordedAudioRef.current = await stopRecording();
+        if (!cancelled) dispatch({ type: 'SILENCE_DETECTED' });
+      } catch (e) {
+        setError(`stopRecording failed: ${String(e)}`);
+        if (!cancelled) dispatch({ type: 'MANUAL_STOP' });
       }
-      dispatch({ type: 'MANUAL_STOP' });
-    });
+    };
+
+    (async () => {
+      // Disarm here too in case the Armed cleanup hasn't yet released the mic.
+      // Ordering: Porcupine off → ding → mic on (single audio consumer rule).
+      await disarmPorcupine().catch(() => {});
+      await playDing();
+      if (cancelled) return;
+      try {
+        await startRecording({
+          onMeter: (db, t) => {
+            if (cancelled || stopping) return;
+            readings.push({ db, t });
+            if (shouldStop(readings)) autoStop();
+          },
+        });
+      } catch (e: unknown) {
+        if (cancelled) return;
+        const name = e instanceof Error ? e.name : '';
+        if (name === 'NotAllowedError') {
+          setError('Mic permission denied. Grant access and tap Wake again.');
+        } else if (name === 'NotFoundError') {
+          setError('No microphone found on this device.');
+        } else {
+          setError(`startRecording failed: ${String(e)}`);
+        }
+        dispatch({ type: 'MANUAL_STOP' });
+        return;
+      }
+      if (cancelled) {
+        await cancelRecording().catch(() => {});
+        return;
+      }
+      hardCapTimer = setTimeout(autoStop, MAX_LISTEN_MS);
+    })();
+
     return () => {
-      // Fires when state leaves Listening. If we transitioned via SILENCE_DETECTED
-      // the button handler already stopped the recorder; this is a no-op then.
+      cancelled = true;
+      if (hardCapTimer) clearTimeout(hardCapTimer);
+      // If autoStop already ran, the recorder is already stopped — cancelRecording is a no-op.
       cancelRecording().catch(() => {});
     };
   }, [state.tag]);
@@ -124,7 +191,14 @@ export default function App() {
     if (state.tag === 'Listening') {
       setIsBusy(true);
       try {
-        recordedAudioRef.current = await stopRecording();
+        try {
+          recordedAudioRef.current = await stopRecording();
+        } catch (e) {
+          // VAD or 10s hard-cap may have already stopped the recorder. That path
+          // dispatches SILENCE_DETECTED itself, so the manual tap should be a no-op.
+          if (e instanceof Error && /not recording/i.test(e.message)) return;
+          throw e;
+        }
         dispatch({ type: 'SILENCE_DETECTED' });
       } catch (e) {
         setError(`stopRecording failed: ${String(e)}`);

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -32,7 +32,7 @@ mobile/
 │   ├── api/                Backend client (every endpoint has a mock counterpart)
 │   └── mocks/
 ├── assets/
-│   ├── hey_chef.ppn
+│   ├── hey_sous.ppn
 │   └── ding.mp3
 └── eas.json
 ```

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -39,9 +39,12 @@
       [
         "expo-build-properties",
         {
-          "ios": { "deploymentTarget": "16.0" }
+          "ios": {
+            "deploymentTarget": "16.0"
+          }
         }
-      ]
+      ],
+      "expo-asset"
     ],
     "extra": {
       "eas": {

--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -1,0 +1,12 @@
+// Custom Metro config: register `.ppn` as an asset extension so we can
+// `require('./assets/hey_sous.ppn')` and load it through `expo-asset` at runtime.
+// PorcupineManager needs an absolute filesystem path to the keyword model.
+
+const { getDefaultConfig } = require('expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+if (!config.resolver.assetExts.includes('ppn')) {
+  config.resolver.assetExts.push('ppn');
+}
+
+module.exports = config;

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -11,6 +11,7 @@
         "@expo/metro-runtime": "~6.1.2",
         "@picovoice/porcupine-react-native": "^4.0.0",
         "expo": "~54.0.33",
+        "expo-asset": "~12.0.12",
         "expo-av": "~16.0.8",
         "expo-build-properties": "^55.0.13",
         "expo-dev-client": "~6.0.20",
@@ -5761,6 +5762,21 @@
         }
       }
     },
+    "node_modules/expo-asset": {
+      "version": "12.0.12",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.12.tgz",
+      "integrity": "sha512-CsXFCQbx2fElSMn0lyTdRIyKlSXOal6ilLJd+yeZ6xaC7I9AICQgscY5nj0QcwgA+KYYCCEQEBndMsmj7drOWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.8",
+        "expo-constants": "~18.0.12"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-av": {
       "version": "16.0.8",
       "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-16.0.8.tgz",
@@ -5796,6 +5812,20 @@
       "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-55.0.3.tgz",
       "integrity": "sha512-l9KHVjTo6MvoeyvwNr6AjckGJm8NIcqZ3QSAh51cWozXW9v2AUjyCyqYtFtyntLWRZ0x/ByYJishpQo4ZQq45Q==",
       "license": "MIT"
+    },
+    "node_modules/expo-constants": {
+      "version": "18.0.13",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
+      "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.13",
+        "@expo/env": "~2.0.8"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/expo-dev-client": {
       "version": "6.0.20",
@@ -6379,33 +6409,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/expo/node_modules/expo-asset": {
-      "version": "12.0.12",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.12.tgz",
-      "integrity": "sha512-CsXFCQbx2fElSMn0lyTdRIyKlSXOal6ilLJd+yeZ6xaC7I9AICQgscY5nj0QcwgA+KYYCCEQEBndMsmj7drOWQ==",
-      "dependencies": {
-        "@expo/image-utils": "^0.8.8",
-        "expo-constants": "~18.0.12"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo/node_modules/expo-constants": {
-      "version": "18.0.13",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
-      "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
-      "dependencies": {
-        "@expo/config": "~12.0.13",
-        "@expo/env": "~2.0.8"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
-      }
     },
     "node_modules/expo/node_modules/expo-file-system": {
       "version": "19.0.21",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -15,6 +15,7 @@
     "@expo/metro-runtime": "~6.1.2",
     "@picovoice/porcupine-react-native": "^4.0.0",
     "expo": "~54.0.33",
+    "expo-asset": "~12.0.12",
     "expo-av": "~16.0.8",
     "expo-build-properties": "^55.0.13",
     "expo-dev-client": "~6.0.20",

--- a/mobile/src/audio/__tests__/porcupine.test.ts
+++ b/mobile/src/audio/__tests__/porcupine.test.ts
@@ -1,0 +1,104 @@
+// Mocks for the native modules. Jest hoists jest.mock calls; only `mock*`-prefixed
+// identifiers may be referenced inside the factory bodies.
+
+const mockManager = {
+  start: jest.fn(async () => {}),
+  stop: jest.fn(async () => {}),
+};
+const mockFromKeywordPaths = jest.fn();
+
+jest.mock('@picovoice/porcupine-react-native', () => ({
+  PorcupineManager: {
+    fromKeywordPaths: mockFromKeywordPaths,
+  },
+}));
+
+jest.mock('expo-asset', () => ({
+  Asset: {
+    fromModule: () => ({
+      downloadAsync: async () => {},
+      localUri: 'file:///tmp/hey_sous.ppn',
+      uri: 'asset:///hey_sous.ppn',
+    }),
+  },
+}));
+
+// The require('../../assets/hey_sous.ppn') inside porcupine.ts has no JS-side meaning
+// in Jest — the asset transformer doesn't know about .ppn. Virtual-mock it.
+jest.mock('../../../../assets/hey_sous.ppn', () => 'mock-ppn-asset-id', { virtual: true });
+
+describe('porcupine — armPorcupine / disarmPorcupine', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockManager.start.mockClear();
+    mockManager.stop.mockClear();
+    mockFromKeywordPaths.mockReset();
+    mockFromKeywordPaths.mockResolvedValue(mockManager);
+    process.env.EXPO_PUBLIC_PICOVOICE_ACCESS_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    delete process.env.EXPO_PUBLIC_PICOVOICE_ACCESS_KEY;
+  });
+
+  it('initializes PorcupineManager with the access key, .ppn path, and sensitivity 0.5', async () => {
+    const { armPorcupine } = require('../porcupine');
+    await armPorcupine(() => {});
+
+    expect(mockFromKeywordPaths).toHaveBeenCalledTimes(1);
+    const args = mockFromKeywordPaths.mock.calls[0];
+    expect(args[0]).toBe('test-key');
+    expect(args[1]).toEqual(['/tmp/hey_sous.ppn']); // 'file://' prefix stripped
+    expect(typeof args[2]).toBe('function'); // detection callback
+    expect(args[6]).toEqual([0.5]); // sensitivities
+  });
+
+  it('starts the manager on arm and stops it on disarm', async () => {
+    const { armPorcupine, disarmPorcupine } = require('../porcupine');
+    await armPorcupine(() => {});
+    expect(mockManager.start).toHaveBeenCalledTimes(1);
+
+    await disarmPorcupine();
+    expect(mockManager.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onWake when the underlying detection callback fires', async () => {
+    const { armPorcupine } = require('../porcupine');
+    const onWake = jest.fn();
+    await armPorcupine(onWake);
+
+    const detectionCallback = mockFromKeywordPaths.mock.calls[0][2];
+    detectionCallback(0);
+    expect(onWake).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses the manager across re-arms and routes to the new onWake', async () => {
+    const { armPorcupine, disarmPorcupine } = require('../porcupine');
+    const firstOnWake = jest.fn();
+    const secondOnWake = jest.fn();
+
+    await armPorcupine(firstOnWake);
+    await disarmPorcupine();
+    await armPorcupine(secondOnWake);
+
+    expect(mockFromKeywordPaths).toHaveBeenCalledTimes(1); // singleton survives
+    expect(mockManager.start).toHaveBeenCalledTimes(2);
+
+    const detectionCallback = mockFromKeywordPaths.mock.calls[0][2];
+    detectionCallback(0);
+    expect(firstOnWake).not.toHaveBeenCalled();
+    expect(secondOnWake).toHaveBeenCalledTimes(1);
+  });
+
+  it('disarmPorcupine before any arm is a safe no-op', async () => {
+    const { disarmPorcupine } = require('../porcupine');
+    await expect(disarmPorcupine()).resolves.toBeUndefined();
+    expect(mockManager.stop).not.toHaveBeenCalled();
+  });
+
+  it('throws a clear error when the Picovoice access key is missing', async () => {
+    delete process.env.EXPO_PUBLIC_PICOVOICE_ACCESS_KEY;
+    const { armPorcupine } = require('../porcupine');
+    await expect(armPorcupine(() => {})).rejects.toThrow(/EXPO_PUBLIC_PICOVOICE_ACCESS_KEY/);
+  });
+});

--- a/mobile/src/audio/__tests__/vad.test.ts
+++ b/mobile/src/audio/__tests__/vad.test.ts
@@ -1,0 +1,66 @@
+import { shouldStop } from '../vad';
+
+// Helper: build a series of readings every 100ms starting at t=0.
+const series = (...db: number[]): Array<{ db: number; t: number }> =>
+  db.map((d, i) => ({ db: d, t: i * 100 }));
+
+describe('shouldStop — pure VAD function', () => {
+  it('returns false on empty buffer', () => {
+    expect(shouldStop([])).toBe(false);
+  });
+
+  it('returns false when only a single reading exists (no time window)', () => {
+    expect(shouldStop([{ db: -60, t: 0 }])).toBe(false);
+  });
+
+  it('returns false when the trailing window is loud', () => {
+    // 16 readings × 100ms = 1500ms span, all above threshold.
+    const readings = series(...new Array(16).fill(-20));
+    expect(shouldStop(readings)).toBe(false);
+  });
+
+  it('returns true when the trailing 1.5s is fully silent (no loud reading at all)', () => {
+    // 16 readings × 100ms span = 1500ms, all below -40 dB.
+    const readings = series(...new Array(16).fill(-60));
+    expect(shouldStop(readings)).toBe(true);
+  });
+
+  it('returns false when the silent span is just under 1.5s', () => {
+    // 15 readings × 100ms span = 1400ms. 1400 < 1500 → false.
+    const readings = series(...new Array(15).fill(-60));
+    expect(shouldStop(readings)).toBe(false);
+  });
+
+  it('returns true when 1.5s of trailing silence follows a loud burst', () => {
+    // Loud at t=0, quiet from t=100..t=1600 (16 quiet readings spanning 1500ms after loud).
+    const readings = [
+      { db: -10, t: 0 },
+      ...new Array(16).fill(0).map((_, i) => ({ db: -55, t: 100 + i * 100 })),
+    ];
+    expect(shouldStop(readings)).toBe(true);
+  });
+
+  it('returns false when a loud reading reappears at the tail (mid-sentence pause case)', () => {
+    // Loud t=0, quiet t=100..t=1500 (under window), loud again at t=1600.
+    const readings = [
+      { db: -10, t: 0 },
+      ...new Array(15).fill(0).map((_, i) => ({ db: -55, t: 100 + i * 100 })),
+      { db: -10, t: 1600 },
+    ];
+    expect(shouldStop(readings)).toBe(false);
+  });
+
+  it('respects a custom thresholdDb', () => {
+    // -30 dB readings are "loud" at default threshold -40 but "quiet" at threshold -20.
+    const readings = series(...new Array(16).fill(-30));
+    expect(shouldStop(readings)).toBe(false);
+    expect(shouldStop(readings, { thresholdDb: -20 })).toBe(true);
+  });
+
+  it('respects a custom silenceMs window', () => {
+    // 1500ms of quiet — true at default 1500, false at 2500.
+    const readings = series(...new Array(16).fill(-60));
+    expect(shouldStop(readings, { silenceMs: 1500 })).toBe(true);
+    expect(shouldStop(readings, { silenceMs: 2500 })).toBe(false);
+  });
+});

--- a/mobile/src/audio/ding.ts
+++ b/mobile/src/audio/ding.ts
@@ -1,0 +1,26 @@
+// 150ms acoustic confirmation that plays after wake-word detection and BEFORE
+// the mic opens (root CLAUDE.md rule §4.2). Lazy-requires expo-av so the web
+// bundle and Jest jsdom env never try to load ExponentAV.
+//
+// A failure to play the ding must NOT wedge the pipeline — silence the rejection
+// and continue; the user just won't hear the tick.
+
+export async function playDing(): Promise<void> {
+  try {
+    const { Audio } = require('expo-av');
+    const { sound } = await Audio.Sound.createAsync(
+      require('../../assets/ding.mp3'),
+      { shouldPlay: true },
+    );
+    await new Promise<void>((resolve) => {
+      sound.setOnPlaybackStatusUpdate((status: any) => {
+        if (status.isLoaded && status.didJustFinish) resolve();
+      });
+      // Hard ceiling so a malformed ding doesn't block the flow.
+      setTimeout(resolve, 500);
+    });
+    await sound.unloadAsync().catch(() => {});
+  } catch {
+    // swallow — see file header
+  }
+}

--- a/mobile/src/audio/ding.web.ts
+++ b/mobile/src/audio/ding.web.ts
@@ -1,0 +1,4 @@
+// Web no-op — the on-screen state badge is the visual confirmation here.
+export async function playDing(): Promise<void> {
+  return;
+}

--- a/mobile/src/audio/porcupine.ts
+++ b/mobile/src/audio/porcupine.ts
@@ -1,10 +1,58 @@
-// TODO(rh/wake-word): Porcupine requires the custom dev client on a real device.
-// Cannot run on web or Expo Go. See .claude/skills/expo-workflow/SKILL.md.
+// Native (iOS/Android) Porcupine wake-word listener. Metro picks porcupine.web.ts on web.
+// Root CLAUDE.md rule 1: only one audio consumer at a time. Porcupine holds the mic
+// in Armed; it must be stopped before expo-av starts recording.
+//
+// PorcupineManager and expo-asset are lazy-required inside function bodies so Jest's
+// jsdom env never tries to load the native modules at import time, and so the manager
+// itself is only created on first arm (avoiding a heavy native init at app launch).
+//
+// Re-arm pattern: a single PorcupineManager singleton survives across arm/disarm cycles
+// (model reload would cost ~1s). The detection callback indirects through `currentOnWake`,
+// so swapping callbacks across cycles is free.
 
-export async function armPorcupine(_onWake: () => void): Promise<void> {
-  return;
+const SENSITIVITY = 0.5;
+
+let manager: any = null;
+let currentOnWake: (() => void) | null = null;
+
+async function ensureManager(): Promise<any> {
+  if (manager) return manager;
+
+  const accessKey = process.env.EXPO_PUBLIC_PICOVOICE_ACCESS_KEY;
+  if (!accessKey) {
+    throw new Error('EXPO_PUBLIC_PICOVOICE_ACCESS_KEY missing — set it in mobile/.env');
+  }
+
+  const { PorcupineManager } = require('@picovoice/porcupine-react-native');
+  const { Asset } = require('expo-asset');
+
+  const asset = Asset.fromModule(require('../../assets/hey_sous.ppn'));
+  await asset.downloadAsync();
+  const localUri: string = asset.localUri ?? asset.uri;
+  const keywordPath = localUri.startsWith('file://') ? localUri.slice('file://'.length) : localUri;
+
+  manager = await PorcupineManager.fromKeywordPaths(
+    accessKey,
+    [keywordPath],
+    (_keywordIndex: number) => {
+      currentOnWake?.();
+    },
+    undefined,
+    undefined,
+    undefined,
+    [SENSITIVITY],
+  );
+  return manager;
+}
+
+export async function armPorcupine(onWake: () => void): Promise<void> {
+  currentOnWake = onWake;
+  const m = await ensureManager();
+  await m.start();
 }
 
 export async function disarmPorcupine(): Promise<void> {
-  return;
+  currentOnWake = null;
+  if (!manager) return;
+  await manager.stop();
 }

--- a/mobile/src/audio/porcupine.web.ts
+++ b/mobile/src/audio/porcupine.web.ts
@@ -1,0 +1,10 @@
+// Web no-op — Porcupine is iOS/Android only. The manual Wake button in App.tsx
+// is the web-side fallback, so wake-word detection silently does nothing here.
+
+export async function armPorcupine(_onWake: () => void): Promise<void> {
+  return;
+}
+
+export async function disarmPorcupine(): Promise<void> {
+  return;
+}

--- a/mobile/src/audio/recorder.ts
+++ b/mobile/src/audio/recorder.ts
@@ -4,11 +4,13 @@
 // expo-av is lazy-required inside each function so Jest's jsdom env never tries
 // to load ExponentAV (which has no JS fallback).
 
-import type { RecordedAudio } from './types';
+import type { RecordedAudio, StartRecordingOptions } from './types';
+
+const METER_INTERVAL_MS = 100;
 
 let current: any = null;
 
-export async function startRecording(): Promise<void> {
+export async function startRecording(opts: StartRecordingOptions = {}): Promise<void> {
   if (current) throw new Error('already recording');
   const { Audio } = require('expo-av');
   const perm = await Audio.requestPermissionsAsync();
@@ -18,8 +20,21 @@ export async function startRecording(): Promise<void> {
     allowsRecordingIOS: true,
     playsInSilentModeIOS: true,
   });
+  const recordingOptions = {
+    ...Audio.RecordingOptionsPresets.HIGH_QUALITY,
+    isMeteringEnabled: true,
+  };
+  const onStatus = opts.onMeter
+    ? (status: any) => {
+        if (status.isRecording && typeof status.metering === 'number') {
+          opts.onMeter!(status.metering, status.durationMillis ?? 0);
+        }
+      }
+    : null;
   const { recording } = await Audio.Recording.createAsync(
-    Audio.RecordingOptionsPresets.HIGH_QUALITY,
+    recordingOptions,
+    onStatus,
+    METER_INTERVAL_MS,
   );
   current = recording;
 }

--- a/mobile/src/audio/recorder.web.ts
+++ b/mobile/src/audio/recorder.web.ts
@@ -1,14 +1,16 @@
 // Web MediaRecorder implementation. Metro picks this over recorder.ts on web.
 // Root CLAUDE.md rule 1: one audio consumer at a time — release the stream on stop/cancel.
+// `onMeter` from StartRecordingOptions is accepted but ignored — MediaRecorder
+// has no built-in metering and we rely on the manual Stop button on web.
 
-import type { RecordedAudio } from './types';
+import type { RecordedAudio, StartRecordingOptions } from './types';
 
 let mediaRecorder: MediaRecorder | null = null;
 let stream: MediaStream | null = null;
 let chunks: Blob[] = [];
 let stopPromise: Promise<Blob> | null = null;
 
-export async function startRecording(): Promise<void> {
+export async function startRecording(_opts: StartRecordingOptions = {}): Promise<void> {
   if (mediaRecorder) throw new Error('already recording');
   stream = await navigator.mediaDevices.getUserMedia({ audio: true });
   chunks = [];

--- a/mobile/src/audio/types.ts
+++ b/mobile/src/audio/types.ts
@@ -5,3 +5,12 @@ export type RecordedAudio = Blob | NativeRecording;
 export function isNativeRecording(audio: RecordedAudio): audio is NativeRecording {
   return typeof audio === 'object' && audio !== null && 'uri' in audio && 'mime' in audio;
 }
+
+// Per-progress-tick metering callback. `dbfs` is the loudness floor reported by
+// expo-av (≤0; quieter is more negative). `tMs` is monotonic ms since recording start.
+// Web ignores this callback — MediaRecorder doesn't expose metering.
+export type MeterCallback = (dbfs: number, tMs: number) => void;
+
+export interface StartRecordingOptions {
+  onMeter?: MeterCallback;
+}

--- a/mobile/src/audio/vad.ts
+++ b/mobile/src/audio/vad.ts
@@ -1,0 +1,39 @@
+// Voice activity detection — pure function, no expo-av imports so it's unit-testable.
+// Treats a reading at or above `thresholdDb` as voiced. Returns true when the
+// trailing window of duration `silenceMs` contains no voiced readings AND the
+// buffer spans at least `silenceMs` of wall-clock time.
+//
+// Defaults match design doc §4 (revised to 1.5s for "hey sous"). Tune per demo
+// environment. The 10s hard cap lives in App.tsx, not here.
+
+export interface MeterReading {
+  db: number;
+  t: number;
+}
+
+export interface ShouldStopOptions {
+  thresholdDb?: number;
+  silenceMs?: number;
+}
+
+const DEFAULT_THRESHOLD_DB = -40;
+const DEFAULT_SILENCE_MS = 1500;
+
+export function shouldStop(
+  readings: ReadonlyArray<MeterReading>,
+  opts: ShouldStopOptions = {},
+): boolean {
+  if (readings.length === 0) return false;
+  const thresholdDb = opts.thresholdDb ?? DEFAULT_THRESHOLD_DB;
+  const silenceMs = opts.silenceMs ?? DEFAULT_SILENCE_MS;
+
+  const now = readings[readings.length - 1].t;
+
+  for (let i = readings.length - 1; i >= 0; i--) {
+    if (readings[i].db >= thresholdDb) {
+      return now - readings[i].t >= silenceMs;
+    }
+  }
+
+  return now - readings[0].t >= silenceMs;
+}

--- a/mobile/src/state/__tests__/machine.test.ts
+++ b/mobile/src/state/__tests__/machine.test.ts
@@ -92,6 +92,32 @@ describe('state machine — invalid transitions are no-ops', () => {
   });
 });
 
+describe('state machine — full voice loop re-arms cleanly', () => {
+  // Wake-word + VAD route. Both triggers fire the same events as the manual
+  // buttons did (WAKE_DETECTED, SILENCE_DETECTED), so this round-trip exercises
+  // the actual rh/wake-word flow.
+  it('cycles Armed → Listening → Processing → Speaking → Armed twice without leaking state', () => {
+    const events: Action[] = [
+      { type: 'WAKE_DETECTED' },
+      { type: 'SILENCE_DETECTED' },
+      { type: 'BACKEND_RESPONDED', response: utterance },
+      { type: 'PLAYBACK_ENDED' },
+      { type: 'WAKE_DETECTED' },
+      { type: 'SILENCE_DETECTED' },
+      { type: 'BACKEND_RESPONDED', response: utterance },
+      { type: 'PLAYBACK_ENDED' },
+    ];
+    const tags = ['Listening', 'Processing', 'Speaking', 'Armed', 'Listening', 'Processing', 'Speaking', 'Armed'];
+    let s = initialState;
+    events.forEach((evt, i) => {
+      s = reducer(s, evt);
+      expect(s.tag).toBe(tags[i]);
+    });
+    expect(s.context.lastResponse).toBe(utterance);
+    expect(s.context.currentIngredients).toEqual(utterance.current_ingredients);
+  });
+});
+
 describe('state machine — FINALIZE is terminal', () => {
   it('any state + FINALIZE → Done', () => {
     for (const tag of ['Armed', 'Listening', 'Processing', 'Speaking'] as const) {


### PR DESCRIPTION
## What

Replaces the manual Wake/Stop buttons with Porcupine wake-word detection ("hey sous", pronounced "sue") and metering-based VAD auto-stop. The phone is now hands-free: say "hey sous" → ding → speak → app auto-stops after 1.5 s of silence (or 10 s hard cap) → backend → TTS → re-arms. Manual buttons remain as the voice-pipeline-debug §4 fallback.

## Why

Implements the M1 wake-word + mic milestone from design doc §4 / §12. Plan file: `~/.claude/plans/implementation-prompt-rh-wake-word-task-jolly-garden.md`. The state-machine event vocabulary (`WAKE_DETECTED`, `SILENCE_DETECTED`) is unchanged — buttons and voice both fire the same events.

## How to test

**Tests already run locally (all green):**

```bash
cd mobile && npx jest                              # 55/55 passing (9 new vad, 6 new porcupine, +1 round-trip)
cd mobile && node_modules/.bin/tsc --noEmit        # clean
cd backend && uv run pytest tests/smoke/ -x        # 2/2 passing
```

**Pre-existing failure (NOT caused by this branch):** `backend/tests/unit/test_utterances.py::test_simple_ingredient_with_qty` fails on this branch *and* on a clean `main` checkout. It's in `backend/gemini_client/` (Atharva's territory). Flagged in `docs/notes/2026-04-18-gemini-client-test-utterances-fail.md`.

**Before EAS rebuild — manual blockers (not Claude-doable):**

1. Train "hey sous" in Picovoice Console → iOS platform → confirm phoneme preview reads "hey sue" (not "hey souz") → export `hey_sous_ios.ppn` → drop into `mobile/assets/hey_sous.ppn` (replaces empty placeholder).
2. Drop a 150 ms royalty-free `ding.mp3` into `mobile/assets/` (replaces empty placeholder).
3. Set `EXPO_PUBLIC_PICOVOICE_ACCESS_KEY` in local `mobile/.env`.
4. Add the same key to EAS dev env: `eas env:create --environment development --name EXPO_PUBLIC_PICOVOICE_ACCESS_KEY --value <key>`.
5. Rebuild: `eas build --profile development --platform ios` (~15–30 min). Then `npx expo start --dev-client`.

**On-device smoke (after EAS rebuild):**

- Say "hey sous" → hear ding → speak "olive oil" → stop → app auto-stops within 1.5–2 s → processes → TTS → re-arms. Repeat 5× consecutively to catch re-arm bugs.
- 30 s in a quiet room with TV/radio in the background — count Porcupine false triggers; if >1, lower `SENSITIVITY` in `mobile/src/audio/porcupine.ts`.
- Manual Wake → record → Manual Stop still behaves identically to today.

## Checklist

- [x] Tests added/updated and passing (`uv run pytest tests/smoke/` / `npm test`)
- [x] Smoke test green: `cd backend && uv run pytest tests/smoke/ -x`
- [x] No `.env` in diff; `.env.example` updated (added `EXPO_PUBLIC_PICOVOICE_ACCESS_KEY`)
- [x] API contract unchanged — no schema/route edits
- [x] Rebased on `main` (single linear commit on top of `7d441c4`)
- [x] `mobile/CLAUDE.md` updated (assets layout reference: `hey_chef.ppn` → `hey_sous.ppn`)
- [x] No edits under `backend/gemini_client/` (the failing test there is pre-existing on main and flagged in `docs/notes/`)

## New dependency

- `expo-asset@~12.0.12` — added via `npx expo install expo-asset`. Needed because `PorcupineManager.fromKeywordPaths` requires an absolute filesystem path; `expo-asset` downloads the bundled `.ppn` to a runtime path.
- Also added: `mobile/metro.config.js` registering `.ppn` as a Metro asset extension so `require('../../assets/hey_sous.ppn')` resolves.

## Reviewer notes

- **Single audio consumer rule** is enforced by the strict `disarmPorcupine → await → ding → await → startRecording` sequence in the Listening effect (`mobile/App.tsx`). The Armed-effect cleanup also disarms; double-disarm is idempotent.
- **300 ms re-arm buffer** unchanged at `PLAYBACK_REARM_MS = 300`. Bump to 500 ms if device testing shows self-trigger on TTS (see `voice-pipeline-debug` §6).
- **Code review status:** local `code-reviewer` subagent returned `pass` with 5 documentation-style warnings (placeholder asset caveat, Android-only path strip, dep-name disclosure) — all addressed in this PR description or scoped out as iOS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)