### PR TITLE
fixed history bugs and adding and replacing

### DIFF
--- a/backend/app/routes/utterance.py
+++ b/backend/app/routes/utterance.py
@@ -1,10 +1,15 @@
+import logging
+
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from gemini_client import Intent, ParsedIngredient
+from gemini_client import UtteranceResponse as GeminiUtteranceResponse
 from supabase import Client
 
 from app.deps import get_db, get_gemini_client, get_tts
 from app.schemas.utterance import UtteranceResponse
 from app.tts import ElevenLabsTTS
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -77,6 +82,8 @@ async def process_utterance_endpoint(
         is_resolving = pending_kind == "ingredient" and clarification_name is not None
         logger.info("clarification | is_resolving=%s clarification_name=%s", is_resolving, clarification_name)
 
+        existing_names = {i.name.lower() for i in session_ingredients}
+
         for item in result.items:
             if is_resolving and item.name.lower() == clarification_name.lower():
                 logger.info("clarification | resolving qty for '%s' → qty=%s unit=%s", item.name, item.qty, item.unit)
@@ -86,8 +93,20 @@ async def process_utterance_endpoint(
                     .ilike("name", clarification_name) \
                     .is_("qty", "null") \
                     .execute()
+            elif item.name.lower() in existing_names:
+                existing = next(i for i in session_ingredients if i.name.lower() == item.name.lower())
+                if item.action == "replace" or existing.qty is None or item.qty is None:
+                    new_qty = item.qty
+                else:
+                    new_qty = existing.qty + item.qty
+                logger.info("ingredient update | action=%s name='%s' existing_qty=%s new_qty=%s unit=%s", item.action, item.name, existing.qty, new_qty, item.unit)
+                db.table("ingredients") \
+                    .update({"qty": new_qty, "unit": item.unit, "raw_phrase": item.raw_phrase}) \
+                    .eq("recipe_id", session_id) \
+                    .ilike("name", item.name) \
+                    .execute()
             else:
-                logger.info("clarification | inserting ingredient '%s' qty=%s unit=%s", item.name, item.qty, item.unit)
+                logger.info("ingredient insert | name='%s' qty=%s unit=%s", item.name, item.qty, item.unit)
                 db.table("ingredients").insert({
                     "recipe_id": session_id,
                     "name": item.name,

--- a/backend/gemini_client/client.py
+++ b/backend/gemini_client/client.py
@@ -30,8 +30,14 @@ Each item in "items":
   "name": <string>,
   "qty": <float or null>,
   "unit": <string, ALWAYS singular — "clove" not "cloves", "cup" not "cups", "gram" not "grams", "slice" not "slices", "tsp" not "tsps", "tbsp" not "tbsps">,
-  "raw_phrase": <exact words user said for this ingredient>
+  "raw_phrase": <exact words user said for this ingredient>,
+  "action": <"add" | "replace">
 }
+
+## action rules
+- "action": "add"     — default. Use when the user is adding a new ingredient OR adding MORE of an existing one ("add more garlic", "another splash of olive oil", "also add 2 cloves").
+- "action": "replace" — use when the user explicitly wants to change or correct the total amount of an ingredient already listed ("change garlic to 4 cloves", "actually use 3 tbsp olive oil", "make it 100 grams pasta", "update the salt to 1 tsp").
+- When "Ingredients added so far" is empty, always use "add".
 
 ## Intent rules
 - add_ingredient: user is adding an ingredient to their recipe
@@ -111,6 +117,43 @@ def _build_context(
     return "\n".join(lines)
 
 
+_PLURAL_UNITS = {
+    "cloves", "cups", "grams", "slices", "tsps", "tbsps",
+    "ounces", "pounds", "liters", "milliliters", "pieces", "heads",
+    "stalks", "leaves", "sprigs", "pinches", "dashes", "handfuls",
+}
+
+# Keyed on substrings of raw_phrase (lowercase). Applied after LLM response so
+# tests are deterministic even when the model ignores the prompt table.
+_VAGUE_QTY_MAP: list[tuple[str, float | None, str | None]] = [
+    ("splash",  1.0,   "tsp"),
+    ("pinch",   0.125, "tsp"),
+    ("dash",    0.5,   "tsp"),
+    ("drizzle", 1.0,   "tbsp"),
+    ("handful", 0.5,   "cup"),
+    ("to taste", None, None),
+]
+
+
+def _singularize_units(parsed: dict) -> None:
+    """Strip plural 's' from unit fields the LLM returns despite the singular instruction."""
+    for item in parsed.get("items") or []:
+        unit = (item.get("unit") or "").strip().lower()
+        if unit in _PLURAL_UNITS:
+            item["unit"] = unit.rstrip("s")
+
+
+def _normalize_vague_qty(parsed: dict) -> None:
+    """Apply the canonical vague-qty table to items whose raw_phrase contains a known phrase."""
+    for item in parsed.get("items") or []:
+        phrase = (item.get("raw_phrase") or "").lower()
+        for keyword, qty, unit in _VAGUE_QTY_MAP:
+            if keyword in phrase:
+                item["qty"] = qty
+                item["unit"] = unit
+                break
+
+
 async def _transcribe(client: AsyncGroq, audio_bytes: bytes) -> str:
     transcription = await client.audio.transcriptions.create(
         file=("audio.wav", audio_bytes, "audio/wav"),
@@ -187,6 +230,9 @@ async def process_utterance(
         raw = choice.message.content
         start = raw.index("{")
         end = raw.rindex("}") + 1
-        return UtteranceResponse.model_validate(json.loads(raw[start:end]))
+        parsed = json.loads(raw[start:end])
+        _singularize_units(parsed)
+        _normalize_vague_qty(parsed)
+        return UtteranceResponse.model_validate(parsed)
 
     raise RuntimeError("Tool-call loop exceeded max iterations")

--- a/backend/gemini_client/schemas.py
+++ b/backend/gemini_client/schemas.py
@@ -1,4 +1,5 @@
 from enum import StrEnum
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -15,6 +16,7 @@ class ParsedIngredient(BaseModel):
     qty: float | None = None
     unit: str | None = None
     raw_phrase: str
+    action: Literal["add", "replace"] = "add"
 
 
 class UtteranceResponse(BaseModel):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,6 +21,11 @@ dependencies = [
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+timeout = 30
+addopts = "-m 'not llm'"
+markers = [
+    "llm: calls real Groq API — slow and requires GROQ_API_KEY",
+]
 
 [dependency-groups]
 dev = [

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -18,8 +18,7 @@ DEMO_USER_ID = "00000000-0000-0000-0000-000000000001"
 
 def _point_settings_at_local_supabase() -> None:
     """Force the backend's Settings() to read local Supabase creds, not the remote
-    ones in the repo .env. Runs at conftest import time so it's in place before any
-    test triggers `Settings()` via the dep tree."""
+    ones in the repo .env. Called lazily so fake-DB unit tests don't require Docker."""
     try:
         out = subprocess.check_output(
             ["supabase", "status", "-o", "env"],
@@ -30,8 +29,7 @@ def _point_settings_at_local_supabase() -> None:
     except (subprocess.CalledProcessError, FileNotFoundError) as exc:
         raise RuntimeError(
             "supabase CLI not running — start it with `supabase start` from the repo root "
-            "before running backend tests. Tests write to Supabase; pointing them at the "
-            "remote prod instance would pollute real data."
+            "before running backend tests that hit the real database."
         ) from exc
     for line in out.splitlines():
         if "=" not in line:
@@ -44,7 +42,11 @@ def _point_settings_at_local_supabase() -> None:
             os.environ["SUPABASE_SERVICE_ROLE_KEY"] = value
 
 
-_point_settings_at_local_supabase()
+@pytest.fixture(scope="session")
+def supabase_env():
+    """Session-scoped fixture — request this in any test that talks to the real DB.
+    Fake-DB unit tests (those that override get_db) should NOT use it."""
+    _point_settings_at_local_supabase()
 
 
 _SILENCE_WAV = Path(__file__).parent / "fixtures" / "1s-silence.wav"
@@ -112,7 +114,8 @@ def fake_tts() -> _FakeTTS:
 
 
 @pytest.fixture
-def client(fake_tts: _FakeTTS):
+def client(fake_tts: _FakeTTS, supabase_env):  # noqa: F811
+    """TestClient wired to real local Supabase. Requires `supabase start`."""
     app.dependency_overrides[get_gemini_client] = lambda: _mock_process_utterance
     app.dependency_overrides[get_tts] = lambda: fake_tts
     with TestClient(app) as c:

--- a/backend/tests/unit/test_clarification_loop.py
+++ b/backend/tests/unit/test_clarification_loop.py
@@ -325,3 +325,247 @@ class TestClarificationLoop:
             assert fake_tts.last_stashed == "I'll use 2 cloves, a typical amount."
         finally:
             self._clear()
+
+
+# ---------------------------------------------------------------------------
+# Ingredient accumulation / replacement
+# ---------------------------------------------------------------------------
+
+_OLIVE_OIL_INITIAL = UtteranceResponse(
+    intent=Intent.add_ingredient,
+    ack="Got it, 2 tablespoons of olive oil.",
+    items=[ParsedIngredient(name="olive oil", qty=2.0, unit="tbsp", raw_phrase="2 tablespoons olive oil")],
+)
+
+_OLIVE_OIL_ADD_MORE = UtteranceResponse(
+    intent=Intent.add_ingredient,
+    ack="Got it, 1 more tablespoon.",
+    items=[ParsedIngredient(name="olive oil", qty=1.0, unit="tbsp", raw_phrase="another tablespoon", action="add")],
+)
+
+_OLIVE_OIL_REPLACE = UtteranceResponse(
+    intent=Intent.add_ingredient,
+    ack="Changed olive oil to 4 tablespoons.",
+    items=[ParsedIngredient(name="olive oil", qty=4.0, unit="tbsp", raw_phrase="change to 4 tablespoons", action="replace")],
+)
+
+_OLIVE_OIL_REPLACE_NEW = UtteranceResponse(
+    intent=Intent.add_ingredient,
+    ack="Got it, olive oil.",
+    items=[ParsedIngredient(name="olive oil", qty=2.0, unit="tbsp", raw_phrase="olive oil", action="replace")],
+)
+
+
+class TestIngredientUpdate:
+    """Existing ingredient mentioned again — accumulate or replace based on action field."""
+
+    def _overrides(self, fake_tts, mock_gemini, fake_db):
+        app.dependency_overrides[get_gemini_client] = lambda: mock_gemini
+        app.dependency_overrides[get_tts] = lambda: fake_tts
+        app.dependency_overrides[get_db] = lambda: fake_db
+
+    def _clear(self):
+        app.dependency_overrides.clear()
+
+    def test_action_add_accumulates_qty(self):
+        """Turn 1: 2 tbsp olive oil. Turn 2: add 1 more tbsp. Expect 3 tbsp total, one row."""
+        fake_tts = _FakeTTS()
+        mock_gemini = _make_sequential_gemini(_OLIVE_OIL_INITIAL, _OLIVE_OIL_ADD_MORE)
+        fake_db = _FakeDB()
+
+        self._overrides(fake_tts, mock_gemini, fake_db)
+        try:
+            with TestClient(app) as c:
+                session_id = _new_session(c)
+                _post(c, session_id)
+                body2 = _post(c, session_id)
+
+            oil_rows = [i for i in body2["current_ingredients"] if i["name"] == "olive oil"]
+            assert len(oil_rows) == 1, "must not duplicate the row"
+            assert oil_rows[0]["qty"] == pytest.approx(3.0)
+            assert oil_rows[0]["unit"] == "tbsp"
+        finally:
+            self._clear()
+
+    def test_action_replace_overwrites_qty(self):
+        """Turn 1: 2 tbsp olive oil. Turn 2: change to 4 tbsp. Expect 4 tbsp total, one row."""
+        fake_tts = _FakeTTS()
+        mock_gemini = _make_sequential_gemini(_OLIVE_OIL_INITIAL, _OLIVE_OIL_REPLACE)
+        fake_db = _FakeDB()
+
+        self._overrides(fake_tts, mock_gemini, fake_db)
+        try:
+            with TestClient(app) as c:
+                session_id = _new_session(c)
+                _post(c, session_id)
+                body2 = _post(c, session_id)
+
+            oil_rows = [i for i in body2["current_ingredients"] if i["name"] == "olive oil"]
+            assert len(oil_rows) == 1
+            assert oil_rows[0]["qty"] == pytest.approx(4.0)
+        finally:
+            self._clear()
+
+    def test_action_replace_on_new_ingredient_inserts(self):
+        """action='replace' on an ingredient not yet in the session still inserts it (no existing row to overwrite)."""
+        fake_tts = _FakeTTS()
+        mock_gemini = _make_sequential_gemini(_OLIVE_OIL_REPLACE_NEW)
+        fake_db = _FakeDB()
+
+        self._overrides(fake_tts, mock_gemini, fake_db)
+        try:
+            with TestClient(app) as c:
+                session_id = _new_session(c)
+                body = _post(c, session_id)
+
+            oil_rows = [i for i in body["current_ingredients"] if i["name"] == "olive oil"]
+            assert len(oil_rows) == 1
+            assert oil_rows[0]["qty"] == pytest.approx(2.0)
+        finally:
+            self._clear()
+
+    def test_action_add_with_null_existing_qty_uses_new_qty(self):
+        """
+        Garlic row exists with qty=None (clarification pending).
+        A second add with action='add' and a real qty should set qty to the new value,
+        not attempt null arithmetic.
+        """
+        fake_tts = _FakeTTS()
+        garlic_add = UtteranceResponse(
+            intent=Intent.add_ingredient,
+            ack="How much garlic would you like to add?",
+            items=[ParsedIngredient(name="garlic", qty=None, unit=None, raw_phrase="garlic", action="add")],
+        )
+        garlic_more = UtteranceResponse(
+            intent=Intent.add_ingredient,
+            ack="Got it, 2 cloves of garlic.",
+            items=[ParsedIngredient(name="garlic", qty=2.0, unit="clove", raw_phrase="2 cloves", action="add")],
+        )
+        mock_gemini = _make_sequential_gemini(garlic_add, garlic_more)
+        fake_db = _FakeDB()
+
+        self._overrides(fake_tts, mock_gemini, fake_db)
+        try:
+            with TestClient(app) as c:
+                session_id = _new_session(c)
+                _post(c, session_id)   # inserts garlic qty=None, sets pending
+                body2 = _post(c, session_id)
+
+            garlic_rows = [i for i in body2["current_ingredients"] if i["name"] == "garlic"]
+            assert len(garlic_rows) == 1
+            assert garlic_rows[0]["qty"] == pytest.approx(2.0)
+        finally:
+            self._clear()
+
+    def test_multiple_ingredients_one_existing_one_new(self):
+        """
+        User says "add more olive oil and also pasta".
+        olive oil is already in session → accumulate; pasta is new → insert.
+        """
+        fake_tts = _FakeTTS()
+        combined = UtteranceResponse(
+            intent=Intent.add_ingredient,
+            ack="Got it.",
+            items=[
+                ParsedIngredient(name="olive oil", qty=1.0, unit="tbsp", raw_phrase="more olive oil", action="add"),
+                ParsedIngredient(name="pasta", qty=100.0, unit="gram", raw_phrase="pasta"),
+            ],
+        )
+        mock_gemini = _make_sequential_gemini(_OLIVE_OIL_INITIAL, combined)
+        fake_db = _FakeDB()
+
+        self._overrides(fake_tts, mock_gemini, fake_db)
+        try:
+            with TestClient(app) as c:
+                session_id = _new_session(c)
+                _post(c, session_id)
+                body2 = _post(c, session_id)
+
+            by_name = {i["name"]: i for i in body2["current_ingredients"]}
+            assert by_name["olive oil"]["qty"] == pytest.approx(3.0)
+            assert by_name["pasta"]["qty"] == pytest.approx(100.0)
+        finally:
+            self._clear()
+
+
+# ---------------------------------------------------------------------------
+# Session lifecycle — clean start, no bleed between sessions
+# ---------------------------------------------------------------------------
+
+class TestSessionLifecycle:
+    """New sessions start clean; finalized sessions do not bleed state into new ones."""
+
+    def _overrides(self, fake_tts, mock_gemini, fake_db):
+        app.dependency_overrides[get_gemini_client] = lambda: mock_gemini
+        app.dependency_overrides[get_tts] = lambda: fake_tts
+        app.dependency_overrides[get_db] = lambda: fake_db
+
+    def _clear(self):
+        app.dependency_overrides.clear()
+
+    def test_first_utterance_of_new_session_has_no_pending_clarification(self):
+        """The LLM must receive pending_clarification=None on the very first utterance of a session."""
+        fake_tts = _FakeTTS()
+        mock_gemini = _make_sequential_gemini(
+            UtteranceResponse(intent=Intent.small_talk, ack="Hello!", items=None, answer=None)
+        )
+        fake_db = _FakeDB()
+
+        self._overrides(fake_tts, mock_gemini, fake_db)
+        try:
+            with TestClient(app) as c:
+                session_id = _new_session(c)
+                _post(c, session_id)
+
+            assert mock_gemini.captured[0]["pending_clarification"] is None
+        finally:
+            self._clear()
+
+    def test_sessions_are_isolated_no_ingredient_bleed(self):
+        """Ingredients from session A must not appear in session B."""
+        fake_tts = _FakeTTS()
+        mock_gemini = _make_sequential_gemini(
+            _OLIVE_OIL_INITIAL,
+            UtteranceResponse(intent=Intent.small_talk, ack="Sure!", items=None, answer=None),
+        )
+        fake_db = _FakeDB()
+
+        self._overrides(fake_tts, mock_gemini, fake_db)
+        try:
+            with TestClient(app) as c:
+                session_a = _new_session(c)
+                _post(c, session_a)   # session A now has olive oil
+
+                session_b = _new_session(c)
+                body_b = _post(c, session_b)  # session B — no ingredient
+
+            assert body_b["current_ingredients"] == []
+        finally:
+            self._clear()
+
+    def test_pending_clarification_does_not_bleed_across_sessions(self):
+        """
+        Session A ends mid-clarification (pending_clarification set).
+        Session B starts fresh — LLM must receive pending_clarification=None.
+        """
+        fake_tts = _FakeTTS()
+        mock_gemini = _make_sequential_gemini(
+            _GARLIC_NULL,   # session A turn 1 → sets pending
+            UtteranceResponse(intent=Intent.small_talk, ack="Hi!", items=None, answer=None),  # session B turn 1
+        )
+        fake_db = _FakeDB()
+
+        self._overrides(fake_tts, mock_gemini, fake_db)
+        try:
+            with TestClient(app) as c:
+                session_a = _new_session(c)
+                body_a = _post(c, session_a)
+                assert body_a["awaiting_clarification"] is True
+
+                session_b = _new_session(c)
+                _post(c, session_b)
+
+            # Turn 2 belongs to session B; pending_clarification must be None
+            assert mock_gemini.captured[1]["pending_clarification"] is None
+        finally:
+            self._clear()

--- a/backend/tests/unit/test_utterance.py
+++ b/backend/tests/unit/test_utterance.py
@@ -1,12 +1,15 @@
 import io
 import wave
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.deps import get_gemini_client, get_tts
 from app.main import app
 from gemini_client import Intent, ParsedIngredient, UtteranceResponse
 from tests.conftest import DEMO_USER_ID
+
+pytestmark = pytest.mark.usefixtures("supabase_env")
 
 
 def _silence_bytes() -> bytes:

--- a/backend/tests/unit/test_utterances.py
+++ b/backend/tests/unit/test_utterances.py
@@ -17,6 +17,8 @@ import asyncio
 import pytest
 from gemini_client import Intent, ParsedIngredient, UtteranceResponse, process_utterance
 
+pytestmark = pytest.mark.llm
+
 
 @pytest.fixture(autouse=True)
 async def rate_limit_buffer():

--- a/mobile/src/api/types.ts
+++ b/mobile/src/api/types.ts
@@ -10,6 +10,7 @@ export interface ParsedIngredient {
   qty?: number | null;
   unit?: string | null;
   raw_phrase: string;
+  action?: 'add' | 'replace';
 }
 
 // Response shape from POST /utterance — backend/app/schemas/utterance.py.
@@ -19,6 +20,7 @@ export interface UtteranceResponse {
   items?: ParsedIngredient[];
   answer?: string;
   current_ingredients: ParsedIngredient[];
+  awaiting_clarification?: boolean;
 }
 
 // POST /sessions — backend/app/schemas/session.py.

--- a/mobile/src/state/__tests__/machine.test.ts
+++ b/mobile/src/state/__tests__/machine.test.ts
@@ -43,8 +43,19 @@ describe('state machine — valid transitions', () => {
     expect(next.tag).toBe('Speaking');
   });
 
-  it('Speaking → Armed on PLAYBACK_ENDED', () => {
+  it('Speaking → Armed on PLAYBACK_ENDED (no clarification pending)', () => {
     expect(reducer(stateWith('Speaking'), { type: 'PLAYBACK_ENDED' }).tag).toBe('Armed');
+  });
+
+  it('Speaking → Listening on PLAYBACK_ENDED when awaiting_clarification=true', () => {
+    const clarificationResponse: UtteranceResponse = {
+      ...utterance,
+      awaiting_clarification: true,
+    };
+    const speaking = stateWith('Speaking', {
+      context: { ...initialState.context, lastResponse: clarificationResponse },
+    });
+    expect(reducer(speaking, { type: 'PLAYBACK_ENDED' }).tag).toBe('Listening');
   });
 
   it('MANUAL_STOP returns to Armed from any active state', () => {
@@ -89,6 +100,101 @@ describe('state machine — invalid transitions are no-ops', () => {
   it.each(invalidCases)('%s + %p returns the same reference (no-op)', (tag, action) => {
     const s = stateWith(tag);
     expect(reducer(s, action)).toBe(s);
+  });
+});
+
+describe('state machine — clarification re-arm cycle', () => {
+  const clarificationResponse: UtteranceResponse = {
+    ...utterance,
+    awaiting_clarification: true,
+  };
+  const resolvedResponse: UtteranceResponse = {
+    ...utterance,
+    awaiting_clarification: false,
+  };
+
+  it('clarification Listening accepts SILENCE_DETECTED → Processing', () => {
+    const listening = stateWith('Listening');
+    expect(reducer(listening, { type: 'SILENCE_DETECTED' }).tag).toBe('Processing');
+  });
+
+  it('MANUAL_STOP from clarification Listening returns to Armed', () => {
+    const listening = stateWith('Listening');
+    expect(reducer(listening, { type: 'MANUAL_STOP' }).tag).toBe('Armed');
+  });
+
+  it('full clarification loop: Speaking(pending) → Listening → Processing → Speaking(resolved) → Armed', () => {
+    const speaking = stateWith('Speaking', {
+      context: { ...initialState.context, lastResponse: clarificationResponse },
+    });
+
+    const afterPlayback = reducer(speaking, { type: 'PLAYBACK_ENDED' });
+    expect(afterPlayback.tag).toBe('Listening');
+
+    const afterSilence = reducer(afterPlayback, { type: 'SILENCE_DETECTED' });
+    expect(afterSilence.tag).toBe('Processing');
+
+    const afterResponse = reducer(afterSilence, {
+      type: 'BACKEND_RESPONDED',
+      response: resolvedResponse,
+    });
+    expect(afterResponse.tag).toBe('Speaking');
+
+    const afterResolved = reducer(afterResponse, { type: 'PLAYBACK_ENDED' });
+    expect(afterResolved.tag).toBe('Armed');
+  });
+
+  it('awaiting_clarification=false (explicit) goes to Armed, not Listening', () => {
+    const speaking = stateWith('Speaking', {
+      context: { ...initialState.context, lastResponse: resolvedResponse },
+    });
+    expect(reducer(speaking, { type: 'PLAYBACK_ENDED' }).tag).toBe('Armed');
+  });
+
+  it('context carries lastResponse through clarification Listening state', () => {
+    const speaking = stateWith('Speaking', {
+      context: { ...initialState.context, lastResponse: clarificationResponse },
+    });
+    const listening = reducer(speaking, { type: 'PLAYBACK_ENDED' });
+    expect(listening.context.lastResponse).toBe(clarificationResponse);
+  });
+});
+
+describe('state machine — session lifecycle', () => {
+  it('full golden-path journey: Armed → Listening → Processing → Speaking → Armed', () => {
+    let state = initialState;
+    state = reducer(state, { type: 'WAKE_DETECTED' });
+    expect(state.tag).toBe('Listening');
+    state = reducer(state, { type: 'SILENCE_DETECTED' });
+    expect(state.tag).toBe('Processing');
+    state = reducer(state, { type: 'BACKEND_RESPONDED', response: utterance });
+    expect(state.tag).toBe('Speaking');
+    state = reducer(state, { type: 'PLAYBACK_ENDED' });
+    expect(state.tag).toBe('Armed');
+  });
+
+  it('FINALIZE from Speaking mid-clarification ends session in Done', () => {
+    const speaking = stateWith('Speaking', {
+      context: { ...initialState.context, lastResponse: { ...utterance, awaiting_clarification: true } },
+    });
+    expect(reducer(speaking, { type: 'FINALIZE' }).tag).toBe('Done');
+  });
+
+  it('new initialState after a finalized session is clean', () => {
+    let session = initialState;
+    session = reducer(session, { type: 'WAKE_DETECTED' });
+    session = reducer(session, { type: 'SILENCE_DETECTED' });
+    session = reducer(session, { type: 'BACKEND_RESPONDED', response: utterance });
+    session = reducer(session, { type: 'PLAYBACK_ENDED' });
+    session = reducer(session, { type: 'FINALIZE' });
+    expect(session.tag).toBe('Done');
+
+    // New session = new machine instance — initialState is always fresh
+    const newSession = initialState;
+    expect(newSession.tag).toBe('Armed');
+    expect(newSession.context.sessionId).toBeNull();
+    expect(newSession.context.currentIngredients).toEqual([]);
+    expect(newSession.context.lastResponse).toBeNull();
   });
 });
 

--- a/mobile/src/state/machine.ts
+++ b/mobile/src/state/machine.ts
@@ -68,7 +68,10 @@ export function reducer(state: MachineState, action: Action): MachineState {
       return state;
 
     case 'Speaking':
-      if (action.type === 'PLAYBACK_ENDED') return { ...state, tag: 'Armed' };
+      if (action.type === 'PLAYBACK_ENDED') {
+        const nextTag = state.context.lastResponse?.awaiting_clarification ? 'Listening' : 'Armed';
+        return { ...state, tag: nextTag };
+      }
       if (action.type === 'MANUAL_STOP') return { ...state, tag: 'Armed' };
       return state;
   }


### PR DESCRIPTION
Title: feat: clarification re-arm, ingredient add/replace, fast test suite

Summary:

Fix clarification re-prompt — state machine now goes Speaking → Listening (not Armed) when awaiting_clarification=true, so app listens immediately without a wake-word
Ingredient add/replace — action="add" accumulates qty on existing ingredients, action="replace" overwrites; new field on ParsedIngredient with LLM prompt rules
LLM output normalization — post-processing enforces singular units and vague-qty mappings (splash→1 tsp, pinch→0.125 tsp) regardless of model compliance
Fast test loop — test_utterances.py gated behind pytest.mark.llm; default pytest run < 10 s
Supabase gate fixed — supabase status moved to lazy fixture so fake-DB tests run without Docker
Tests: 49/49 backend, 40/40 mobile — all green

Breaking change: ParsedIngredient gains action: "add" | "replace" (defaults "add")