### PR TITLE
fix: clarification ack/flag sync when LLM ignores prompt rules

### DIFF
--- a/backend/app/routes/utterance.py
+++ b/backend/app/routes/utterance.py
@@ -77,6 +77,7 @@ async def process_utterance_endpoint(
         )
 
     new_pending: str | None = None
+    tts_ack = result.ack  # may be overridden below when a clarification question is synthesized
 
     if result.intent == Intent.add_ingredient and result.items:
         is_resolving = pending_kind == "ingredient" and clarification_name is not None
@@ -118,8 +119,13 @@ async def process_utterance_endpoint(
         incomplete = [i for i in result.items if i.qty is None]
         if incomplete and not is_resolving:
             # Chain clarification for first incomplete item; subsequent null items chain naturally
-            new_pending = _encode_ingredient_clarification(incomplete[0].name, result.ack)
-            logger.info("clarification | asking for qty: ingredient='%s' ack='%s'", incomplete[0].name, result.ack)
+            clarification_question = result.ack
+            if not clarification_question.rstrip().endswith("?"):
+                # LLM wrote a confirmation instead of a question — synthesize the proper question
+                clarification_question = f"How much {incomplete[0].name} would you like to add?"
+                tts_ack = clarification_question
+            new_pending = _encode_ingredient_clarification(incomplete[0].name, clarification_question)
+            logger.info("clarification | asking for qty: ingredient='%s' ack='%s'", incomplete[0].name, clarification_question)
         elif incomplete and is_resolving:
             # LLM failed to resolve — retry clarification for the same ingredient
             new_pending = _encode_ingredient_clarification(clarification_name, result.ack)
@@ -141,7 +147,7 @@ async def process_utterance_endpoint(
     # Design §8: for a question intent the `answer` is the spoken reply;
     # otherwise the `ack` is what the user hears. Fallback to a filler so we never
     # send an empty string to ElevenLabs (which 400s).
-    picked = result.answer if result.intent == Intent.question and result.answer else result.ack
+    picked = result.answer if result.intent == Intent.question and result.answer else tts_ack
     tts_text = (picked or "").strip() or "Okay."
     audio_id = tts.stash_text(tts_text)
 

--- a/backend/gemini_client/client.py
+++ b/backend/gemini_client/client.py
@@ -149,15 +149,22 @@ def _singularize_units(parsed: dict) -> None:
             item["unit"] = unit.rstrip("s")
 
 
-def _normalize_vague_qty(parsed: dict) -> None:
-    """Apply the canonical vague-qty table to items whose raw_phrase contains a known phrase."""
+def _normalize_vague_qty(parsed: dict) -> bool:
+    """Apply the canonical vague-qty table to items whose raw_phrase contains a known phrase.
+
+    Returns True if any item had its qty resolved from null to a concrete value."""
+    resolved_any = False
     for item in parsed.get("items") or []:
         phrase = (item.get("raw_phrase") or "").lower()
+        was_null = item.get("qty") is None
         for keyword, qty, unit in _VAGUE_QTY_MAP:
             if keyword in phrase:
                 item["qty"] = qty
                 item["unit"] = unit
+                if was_null and qty is not None:
+                    resolved_any = True
                 break
+    return resolved_any
 
 
 async def _transcribe(client: AsyncGroq, audio_bytes: bytes) -> str:
@@ -238,7 +245,13 @@ async def process_utterance(
         end = raw.rindex("}") + 1
         parsed = json.loads(raw[start:end])
         _singularize_units(parsed)
-        _normalize_vague_qty(parsed)
+        resolved_vague = _normalize_vague_qty(parsed)
+        # LLM sometimes writes a clarification question for vague phrases it normalized —
+        # replace the ack with a confirmation so TTS doesn't speak an unanswerable question.
+        if resolved_vague and parsed.get("ack", "").rstrip().endswith("?"):
+            items = parsed.get("items") or []
+            phrase = items[0]["raw_phrase"] if items else "that"
+            parsed["ack"] = f"Got it, adding {phrase}."
         return UtteranceResponse.model_validate(parsed)
 
     raise RuntimeError("Tool-call loop exceeded max iterations")


### PR DESCRIPTION
## Summary
- `_normalize_vague_qty` now returns `True` when it promotes a vague null qty (e.g. "splash") to a concrete value; if the LLM still wrote a clarification-question ack, it's replaced with a confirmation so TTS never speaks an unanswerable question
- utterance.py synthesizes `"How much X would you like to add?"` when incomplete items are detected but the LLM ack is a statement — used for both TTS and `pending_clarification` so Groq gets a coherent prompt on turn 2
- Fixes: vague qty flag/ack mismatch, milk-style "Got it" when clarification needed, no manual re-arm required for follow-ups

## Test plan
- [ ] "a splash of oil" → TTS says confirmation, `awaiting_clarification=false`, machine → Armed
- [ ] "add milk" → TTS asks "How much milk would you like to add?", `awaiting_clarification=true`, machine → Listening (auto-arms)
- [ ] Reply with quantity → resolves, `awaiting_clarification=false`, machine → Armed
- [ ] `uv run pytest tests/unit/test_clarification_loop.py -x` — 12/12 pass
- [ ] `uv run pytest tests/smoke/ -x` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)