### PR TITLE
docs: post-hackathon transition (root CLAUDE.md + roadmap + prompts)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file is loaded on every session and every subagent spawn. Keep it lean — 
 
 ## Project
 
-Sous Chef: an AI voice sous chef for an Expo + FastAPI + Gemini + ElevenLabs + Edamam + Supabase + Picovoice Porcupine stack. 36-hour hackathon. Two devs: **Rishi** (branch prefix `rh/`) owns mobile + backend API + integration; **Atharva** (prefix `ad/`) owns `backend/gemini_client/`.
+Sous Chef: an AI voice sous chef on an Expo + FastAPI + Gemini + ElevenLabs + Edamam + Supabase + Picovoice Porcupine stack. The hackathon prototype shipped; the project is now being pushed to production quality.
 
-Demo scenario: 3-minute pasta aglio e olio walk-through. See `.claude/memory/design-doc-summary.md` before anything else — do not re-read the full design doc (`docs/design.md`) unless the summary is insufficient.
+Two devs — **Rishi** (branch prefix `rh/`) and **Atharva** (prefix `ad/`). Free-for-all on issues: either dev can pick up any ticket; branch prefix identifies who's driving the change, not who owns the code. See `.claude/memory/design-doc-summary.md` before substantive work. Do not re-read the full design doc (`docs/design.md`) unless the summary is insufficient; update the summary when the doc changes.
 
 ## Architecture rules (non-negotiable)
 
@@ -17,28 +17,19 @@ Distilled from design doc §4, §7. Full detail in the summary.
 3. **Mobile never talks directly to Gemini / ElevenLabs / Edamam.** Backend is the only server.
 4. **Backend is stateless** except for Supabase state.
 5. **`gemini_client` is a pure function.** `(audio, session_ingredients, pending_clarification) → UtteranceResponse`. Imported, not reimplemented.
-6. **API contract lives in** `docs/design.md` §7 — summary in `.claude/memory/design-doc-summary.md`. Any change to request/response shapes is a breaking change; flag it explicitly.
-
-## Ownership boundaries (HARD)
-
-- **`backend/gemini_client/` is Atharva's.** Atharva edits freely here. Rishi never edits it — a deny rule in his settings blocks him.
-- If you are assisting **Rishi** and integration reveals a bug in `gemini_client`: write a note at `docs/notes/<YYYY-MM-DD>-gemini-client-<slug>.md`, open a GitHub issue tagged for Atharva. Do not patch locally.
-- If you are assisting **Atharva**: gemini_client is your primary domain — edit, test, iterate.
+6. **API contract lives in** `docs/design.md` §7 — summary in `.claude/memory/design-doc-summary.md`. Any change to request/response shapes is a breaking change; flag it explicitly and run `integration-checker`.
 
 ## Git rules (HARD)
 
-**Phase gate — the branching rule turns on only once Atharva has cloned and made at least one commit of his own.** Until then, the repo is a solo scaffolding exercise; committing pre-partner scaffolding straight to `main` is correct and expected. Rishi will tell Claude when to flip the switch ("Atharva has cloned" or similar). Until that signal, skip rule 1 and rule 7 — every other rule below still applies.
+Strict branching is always on. Production quality means we don't commit to `main` even when no one else is looking.
 
-Once the gate is crossed:
-
-1. **Never commit to `main`.** If on `main`, immediately `git switch -c ad/<slug>` (Atharva) or `rh/<slug>` (Rishi).
-2. **`git push` is allowed; `git push --force` is not** — the deny list still blocks force push. Before any push, show the diff + one-sentence summary of what's going out so the dev can object before it hits the remote.
+1. **Never commit to `main`.** If on `main`, immediately `git switch -c <prefix>/<slug>` — `rh/` for Rishi, `ad/` for Atharva. Kebab-case slug, ≤4 words. Examples: `rh/utterance-endpoint`, `ad/gemini-clarification`. The prefix reflects who's driving the change; either dev can work in any part of the codebase.
+2. **`git push` is allowed; `git push --force` is not** — the deny list blocks force push. Before any push, show the diff + one-sentence summary so the dev can object before it hits the remote.
 3. **Never `git reset --hard`, never `--no-verify`, never `--no-gpg-sign`.** Deny list blocks these.
 4. **Never auto-resolve merge conflicts.** On conflict: stop, show the markers, wait.
-5. **Branch naming:** `ad/<short-slug>` for Atharva, `rh/<short-slug>` for Rishi (kebab-case, ≤4 words). Examples: `ad/gemini-clarification`, `rh/utterance-endpoint`.
-6. **Commits:** small, focused, "why" over "what". Never `git add -A` or `git add .` — name specific files.
-7. **PRs as drafts.** Use the template at `.github/pull_request_template.md`.
-8. **Rebase, don't merge.** `git rebase origin/main` to pick up upstream.
+5. **Commits:** small, focused, "why" over "what". Never `git add -A` or `git add .` — name specific files.
+6. **PRs as drafts.** Use the template at `.github/pull_request_template.md`.
+7. **Rebase, don't merge.** `git rebase origin/main` to pick up upstream.
 
 Full reference: `.claude/skills/git-partner-workflow/SKILL.md`.
 
@@ -53,11 +44,11 @@ Full reference: `.claude/skills/git-partner-workflow/SKILL.md`.
 - **`.env` never committed.** Enforced by `.gitignore` + the deny list. If you need a new env var, update `.env.example` in the same commit and flag the key in the PR description.
 - **Never log, echo, or fixture-in secrets.**
 
-Dep-failure runbook lives in `.claude/skills/fastapi-patterns/SKILL.md` and `.claude/skills/expo-workflow/SKILL.md`.
+Dep-failure runbooks: `.claude/skills/fastapi-patterns/SKILL.md`, `.claude/skills/expo-workflow/SKILL.md`.
 
 ## Context discipline (the reason subagents exist)
 
-Main-thread context is the scarcest resource. Every file Claude reads becomes permanent context for the rest of the session. At hour 20, an undisciplined session is slow, expensive, and regressing earlier decisions.
+Main-thread context is the scarcest resource. Every file Claude reads becomes permanent context for the rest of the session.
 
 **Default to subagent delegation for:**
 - Any read >500 lines.
@@ -75,7 +66,7 @@ Main-thread context is the scarcest resource. Every file Claude reads becomes pe
 
 **Start a fresh session per major feature.** CLAUDE.md + `.claude/memory/decisions.md` + `docs/notes/` carry what matters across sessions. The chat history does not.
 
-**~50% context rule.** When you notice main-thread context approaching half of max, proactively suggest: `/compact`, writing state to a note, starting fresh, or delegating more.
+**~50% context rule.** When main-thread context approaches half of max, proactively suggest: `/compact`, writing state to a note, starting fresh, or delegating more.
 
 **Targeted tool use:**
 - `Read` with line ranges when a file exceeds ~200 lines.
@@ -113,18 +104,18 @@ Specific runbooks: `.claude/skills/voice-pipeline-debug/SKILL.md`, `.claude/skil
 
 A change is done only when **all** of the following are true:
 
-1. **Tests pass.** `pytest -x` green for backend changes. `npm test` green for mobile. The `test-runner` subagent confirms.
+1. **Tests pass.** `pytest -x` green for backend. `npm test` green for mobile. The `test-runner` subagent confirms.
 2. **Smoke test passes.** `cd backend && uv run pytest tests/smoke/ -x` — the `/sessions → /utterance → /finalize` integration test.
 3. **`code-reviewer` subagent returns `status: pass`.**
 4. **If API contract touched, `integration-checker` returns `consistent: true`.**
 5. **No hardcoded secrets.** No `.env` in diff.
-6. **Branch is `ad/<slug>` (Atharva) or `rh/<slug>` (Rishi), not `main`.**
+6. **Branch is `<prefix>/<slug>`, not `main`.**
 7. **PR template fields filled in.**
 
 Per-module DoD:
 
 - **M1 wake word + mic** — state machine transitions clean; 300ms re-arm buffer present; ding plays.
-- **M2 utterance processing** — `test_utterances.py` ≥80% in the `gemini_client` test harness. (Atharva's bar; Rishi verifies by running it before integrating.)
+- **M2 utterance processing** — `test_utterances.py` ≥80% in the `gemini_client` test harness.
 - **M3 clarification flow** — `pending_clarification` written and read across utterances; ≥3 test cases for the round-trip.
 - **M4 Q&A handler** — `answer` ≤2 sentences; TTS renders it.
 - **M5 macro computation** — Edamam failure on one ingredient does not fail the whole recipe.
@@ -136,8 +127,8 @@ When Claude first enters `mobile/`, `backend/`, or `backend/gemini_client/` and 
 
 ## Pointers
 
-- **How-to for the current stack:** `.claude/skills/` — expo-workflow, fastapi-patterns, supabase-ops, git-partner-workflow, voice-pipeline-debug, demo-readiness.
-- **What we decided:** `.claude/memory/decisions.md` (append-only). When Rishi accepts a non-trivial architectural call, append an entry (date, decision, rationale, alternatives).
+- **How-to for the current stack:** `.claude/skills/` — expo-workflow, fastapi-patterns, supabase-ops, git-partner-workflow, voice-pipeline-debug, release-readiness.
+- **What we decided:** `.claude/memory/decisions.md` (append-only). When a non-trivial architectural call is accepted, append an entry (date, decision, rationale, alternatives).
 - **Compressed design doc:** `.claude/memory/design-doc-summary.md`.
 - **In-flight working notes:** `docs/notes/<YYYY-MM-DD>-<slug>.md`.
 - **Ephemeral scratch:** `.claude/memory/scratch/` (never referenced across sessions).

--- a/docs/notes/2026-04-19-readme-prompt.md
+++ b/docs/notes/2026-04-19-readme-prompt.md
@@ -1,0 +1,79 @@
+# Prompt — Hackathon README (paste into a fresh Claude Code plan window)
+
+Copy everything between the `---` markers below into a new Claude Code session with `/plan` active.
+
+---
+
+You're going to write the project README for **Sous Chef**, a hackathon submission. The goal is a README that makes a judge in a hurry understand, in under 90 seconds, (a) what it does, (b) why it's cool, and (c) how to run it — and then gives them depth if they want to stick around. Treat this as a high-stakes design deliverable, not boilerplate.
+
+## Project identity
+
+- **Name:** Sous Chef
+- **One-liner:** An AI voice sous chef — tap the mic or say "hey sous", speak ingredients, get back macros and a saved cookbook entry, all hands-free while you cook.
+- **Hackathon timeline:** 36 hours. Demo is a 3-minute live walk-through of pasta aglio e olio.
+- **Team:** two devs. Rishi Dave (mobile + backend API + integration). Atharva (Gemini utterance-understanding client in `backend/gemini_client/`).
+- **Stack:** Expo SDK 54 + React Native, TypeScript strict, FastAPI on Railway, Gemini (utterance parsing), ElevenLabs (voice synthesis), Edamam (macros), Supabase (Postgres + auth), Picovoice Porcupine (wake word).
+
+## What you must do before writing
+
+Before any code, launch up to **3 parallel Explore agents** to map the repo. Do **not** read large files into the main thread. Specifically:
+
+1. One agent reads `docs/design.md` + `.claude/memory/design-doc-summary.md` + `docs/ui.md` and returns a structured digest of: the 3-minute demo script, the Warm Editorial design language, the API contract (§7 of design doc).
+2. One agent reads `backend/app/main.py`, `backend/app/routes/*`, `backend/app/schemas/*`, `supabase/migrations/*` and returns: the actual endpoints deployed, the DB schema, what each endpoint does in one sentence.
+3. One agent reads `mobile/app/**/*.tsx`, `mobile/src/state/machine.ts`, `mobile/src/audio/*` and returns: the screens + routes, the state machine (Armed → Listening → Processing → Speaking), the audio pipeline's single-consumer rule.
+
+Also read the root `CLAUDE.md` yourself for collaboration rules. Do **not** read `backend/gemini_client/` — it's a pure function imported by the backend; a summary of its role is enough.
+
+After exploration, ask me (the user) a short AskUserQuestion for:
+- The demo video URL (YouTube/Vimeo/Loom link) to embed. If I don't have one, a "Demo video coming" placeholder is fine.
+- The team-credits section — just names + roles, or also LinkedIn/GitHub handles?
+- Whether you should include a "Known limitations / cut for demo" section (recommended: yes — honesty lands well with judges).
+
+## Required sections (in this order)
+
+1. **Header block.** Project name as H1. A single-sentence tagline in italics below. Three badges in a row: build status (GitHub Actions if present, else omit), license (MIT assumed, check `LICENSE`), Python version. Use `shields.io`.
+2. **Hero image / GIF.** A screenshot or recorded GIF of the cooking screen mid-session — MicCard listening state with the three gold rings is the money shot. If assets don't exist, leave a clearly-marked `<!-- TODO: add hero.gif -->` placeholder with expected dimensions (recommend 800×450).
+3. **What it is (30-second pitch).** Three short paragraphs max. First paragraph: the scenario (you're cooking, hands dirty, you need a helper). Second: what the app does about it. Third: the technical novelty (voice loop, Gemini as the NLU, real macro resolution via Edamam, editorial design language).
+4. **Demo.** A prominent link to the demo video. Below it, **the exact 3-minute walk-through script** — 6–8 numbered steps that map to the pasta aglio e olio flow. This lets judges replay without watching. Include expected voice lines ("add three cloves of garlic", "how long should I cook the pasta", "I'm done").
+5. **Architecture diagram.** A **mermaid** `flowchart LR` showing: Phone (Porcupine + expo-av) → FastAPI backend → parallel fans to Gemini, Edamam, ElevenLabs, Supabase → response back to phone. Don't overcrowd — 8-10 nodes max.
+6. **State machine diagram.** A **mermaid** `stateDiagram-v2` showing Armed → Listening → Processing → Speaking with transition labels (`WAKE_DETECTED`, `SILENCE_DETECTED`, `BACKEND_RESPONDED`, `PLAYBACK_ENDED`). This is a hackathon-winner detail.
+7. **Tech stack.** A compact two-column markdown table: what role, what tool. Link each tool's homepage.
+8. **Quickstart.** Three top-level subsections: Prereqs (Node 20+, Python 3.12, `uv`, Supabase CLI, Expo account), Backend (`cd backend && uv sync && uvicorn...`), Mobile (`cd mobile && npm ci && npx expo start --tunnel --dev-client`). Include the required `.env` keys for each (names only, with links to where to get them). 4–6 shell blocks total; don't flood it.
+9. **Project layout.** A tree (use `├──` box drawing) showing the top two levels plus one level inside `mobile/` and `backend/`. Prune aggressively — `node_modules`, `.expo`, `.venv` don't appear.
+10. **What we built in 36 hours.** A checklist of features that actually work (voice loop, cookbook with delete + cook-time, editorial UI, real macros via Edamam, Supabase persistence, ElevenLabs TTS). Tick them with `[x]`.
+11. **What we cut and why.** 2–3 items max. Be specific: "Wake word on web (Porcupine is native-only)", "Multi-user auth (demo uses a seeded UUID)". Good judges reward honesty here.
+12. **Challenges we hit.** 2–3 bullets. The single-audio-consumer rule (Porcupine vs expo-av conflict), the Gemini clarification loop state, getting Edamam to not tank the whole recipe on one missing ingredient. One sentence each on what went wrong and how you solved it.
+13. **Credits.** Team members with their scope (one line each). Link to any pre-existing work used.
+14. **License.** One line — "MIT — see [LICENSE](LICENSE)" if that's what the repo has.
+
+## Style and length constraints
+
+- **Target length: 250–350 lines** in the final `.md`. If you're below 200 you haven't said enough; above 400 judges stop reading.
+- **No emoji spam**, but one or two section-header emoji is fine (🍳 for the tagline block maximum).
+- **No rambling intro paragraph** before the tagline.
+- **Code blocks** use language fences (`bash`, `python`, `ts`).
+- **Every image reference must point to a real file or have a clearly-labeled `<!-- TODO -->` stub**. Never fabricate paths.
+- **Never invent features** — only document what's in the repo. If unsure, grep for it or ask.
+
+## Diagrams
+
+Both diagrams go inline as fenced `mermaid` blocks — GitHub renders them natively. Do **not** generate SVGs or PNGs; mermaid source in markdown is the standard for hackathon READMEs and avoids binary churn.
+
+If the user asks for a third diagram, offer a sequence diagram of a single utterance's round trip (phone → /utterance → Gemini → Supabase write → TTS → ack audio streaming back). Don't add it unprompted — three diagrams is the soft ceiling before it feels like a textbook.
+
+## Output
+
+- Write the README to `/Users/rishidave/Documents/sous-chef/README.md`.
+- If a README already exists, **overwrite** it (the hackathon submission README replaces any scaffolding).
+- Before writing, show me the section outline with approximate line counts per section so I can redirect if the balance feels off.
+
+## Verification
+
+After writing:
+1. `wc -l README.md` — confirm 250–350 lines.
+2. `grep -n "TODO" README.md` — print any TODO stubs so I know exactly what still needs filling in (demo video URL, hero image).
+3. Paste the two mermaid blocks' source back to me so I can verify they render cleanly on GitHub (mermaid syntax errors only surface on render).
+
+Don't add CI instructions, contributor guidelines, code of conduct, or any other open-source-project boilerplate — this is a hackathon submission, not an open-source library. Keep it crisp.
+
+---

--- a/docs/notes/2026-04-20-issue-creation-prompt.md
+++ b/docs/notes/2026-04-20-issue-creation-prompt.md
@@ -1,0 +1,96 @@
+# Prompt — Create GitHub Issues from the Post-Hackathon Roadmap
+
+Copy everything between the `---` markers below into a new Claude Code session with `/plan` active. The session will read `docs/sous-ai-roadmap.md`, plan the issue creation carefully, and then (after you approve the plan) use `gh` to create the issues so Rishi and Atharva can each pick which ones to pick up.
+
+---
+
+You're turning `docs/sous-ai-roadmap.md` into real GitHub issues on the `Rishi-Dave/sous.ai` repository using the `gh` CLI. Each `##` section in the roadmap becomes one issue. This is a destructive-on-remote task (creates real issues that land in the repo's issue tracker), so you must go through the full plan-mode workflow and wait for explicit approval before running any `gh issue create` command.
+
+## Repository context
+
+- Repo: `Rishi-Dave/sous.ai` (GitHub), currently on branch `main`
+- Two active contributors: **Rishi Dave** (GitHub handle `Rishi-Dave`) and **Atharva** (find his handle in git log — he authored commits on branches like `ad/*` and `atharvanev/*`; grep `git log --format='%an %ae' | sort -u` to identify)
+- The roadmap at `docs/sous-ai-roadmap.md` is the source of truth. Read it in full before planning.
+- Root `CLAUDE.md` still governs the repo — respect its collaboration rules except where this document specifies otherwise.
+
+## Phase 1 — Explore (single Explore agent is enough)
+
+Launch one Explore agent to answer these questions:
+
+1. Does the repo currently have any open or closed issues? Any existing labels or milestones? Any GitHub project board attached? Use `gh issue list --state all --limit 50`, `gh label list`, `gh project list --owner Rishi-Dave`.
+2. What's Atharva's GitHub handle? Grep the git log for commit authors other than `Rishi-Dave`.
+3. Is there a `.github/ISSUE_TEMPLATE/` directory, and if so what templates exist? They shouldn't block this work but we should honor them if present.
+
+Also, yourself (main thread), read `docs/sous-ai-roadmap.md` in full. It's the authoritative source; do not summarize or synthesize from memory.
+
+## Phase 2 — Plan (1 Plan agent)
+
+Launch one Plan agent with:
+- A copy of the roadmap's section titles + labels + dependencies extracted into a structured list
+- The Phase 1 findings
+- Instructions to return a detailed execution plan for issue creation
+
+The plan must cover:
+
+1. **Label creation.** The roadmap's "Labels to create" section lists every label used. For each label, say whether it already exists (from the Phase 1 scan) or needs to be created with `gh label create`. Assign a color per label family (priorities get a red→green gradient, types get neutral greys, areas get distinct hues). Don't invent new label names; only use what the roadmap calls out.
+2. **Milestone (optional).** Suggest one milestone: `v1 — public beta`, scoped to issues #1–#8 inclusive. Offer to create it or skip based on my preference.
+3. **Issue creation order.** Create issues in roadmap order (#1 first, #14 last) so that when you link dependencies in body text via `Depends on #N`, the referenced issues already exist.
+4. **Title + body format.** Title = roadmap `## N. Title` with the number stripped. Body = the section content verbatim (Why, What to build, Acceptance criteria, Notes for Claude Code), rendered in Markdown exactly as written in the roadmap. Do not paraphrase or abridge — issue bodies should be a faithful copy.
+5. **Dependency linking.** Rewrite `Depends on: #1, #2` lines in the body to use GitHub issue cross-refs once those issues exist (e.g. after #1 is created with issue number 3, `#1` in #2's body becomes `#3`). Maintain a mapping table as you go.
+6. **Assignees.** Do not pre-assign any issue. Both contributors should pick what they want to pick up. Leave assignee empty.
+7. **`gh` command templates.** Show me the exact `gh issue create` command template with variables (title, body, labels) so I can sanity-check before execution.
+
+## Phase 3 — Review
+
+Read the following small files yourself to validate assumptions:
+- `docs/sous-ai-roadmap.md` (confirm label list at the bottom)
+- `CLAUDE.md` (confirm partner workflow, branch naming — these shouldn't affect issue creation but may inform issue body copy)
+- `.github/pull_request_template.md` if it exists (see if there's a format we should mirror)
+
+Use AskUserQuestion to resolve any of:
+- **Create a milestone?** Offer `v1 — public beta` scoped to #1–#8 as the default option.
+- **Create a GitHub project board?** Offer a default layout (columns: `Backlog`, `Next`, `In progress`, `Review`, `Done`) with all new issues added to `Backlog`, or a "skip and just create plain issues" option.
+- **Any roadmap items to skip?** If I say yes, ask which numbers and drop them from the plan.
+
+Do **not** ask about progress or approval in text — that's what ExitPlanMode is for.
+
+## Phase 4 — Write the final plan
+
+Write your final plan to the plan file. Structure:
+
+1. **Context** (why, one paragraph)
+2. **Label strategy** (list: existing / to-create / skip, with chosen colors)
+3. **Milestone + project decision** (reflecting user's answer to AskUserQuestion)
+4. **Issue creation sequence** (numbered table: roadmap # → planned issue title → labels → dep chain)
+5. **Commands to run** (concrete `gh` commands, one per step, with any variables pre-filled)
+6. **Verification** (what to check after every 5 issues and at the end: `gh issue list`, spot-check a rendered issue in the UI, confirm dependency refs resolved)
+7. **Rollback** (what to do if a mistake happens mid-run: `gh issue close --reason "not planned" <number>` for wrongly-created issues, never `gh issue delete` unless user explicitly asks)
+
+## Phase 5 — ExitPlanMode
+
+Wait for approval. Do not call any `gh issue create`, `gh label create`, `gh milestone create`, or `gh project create` before ExitPlanMode is approved. Listing / reading commands (`gh label list`, `gh issue list`) are fine anytime.
+
+## Execution phase (after approval)
+
+Once the plan is approved:
+
+1. Create labels first (all of them, as a batch). Skip ones that already exist.
+2. Create the milestone (if chosen).
+3. Create the project board (if chosen) and note its ID.
+4. Create issues in roadmap order. For each: `gh issue create --title ... --body-file <tmp>.md --label <csv>` with body pulled from the corresponding roadmap section and dependency references rewritten to the issue numbers assigned so far.
+5. After every 5 issues, run `gh issue list --limit 20` and print the titles so the user can sanity-check progress.
+6. After all issues are created, run a final `gh issue list --state open --limit 30` and paste the output back. This is the "done" signal.
+
+## Rules
+
+- **Body fidelity.** Issue bodies should read like the roadmap section. Do not rewrite. The only allowed transformation is replacing `#1`, `#2`, etc. with the actual created issue numbers.
+- **No assignees.** Leave every issue unassigned so Rishi and Atharva can pick freely.
+- **Idempotency.** If the session is interrupted and restarted, running the plan again should not create duplicates. Before creating each issue, check `gh issue list --search "<title>"` to see if it exists. If it does, skip it.
+- **Don't push code.** This task only touches GitHub issues, labels, milestones, and possibly a project board. No commits, no branches, no file changes in the working tree except the plan file itself.
+- **If `gh` isn't authenticated**, stop and ask the user to run `gh auth status` — do not try to work around auth failures.
+
+## Output file for the plan
+
+Write your plan to the standard plan-mode location. When you're done executing, also append a short "Execution log" section to the plan file with: timestamp of each issue creation batch, any issues that already existed and were skipped, and final issue count.
+
+---

--- a/docs/sous-ai-roadmap.md
+++ b/docs/sous-ai-roadmap.md
@@ -1,0 +1,466 @@
+# sous.ai — Post-Hackathon Roadmap
+
+Prioritized list of changes for Claude Code to convert into GitHub issues. Ordered high-impact to low-impact. Each item is scoped to be a standalone issue: includes context, concrete acceptance criteria, and rough effort estimate.
+
+**Claude Code: create one issue per `##` section below. Use the section heading as the issue title (strip the number). Use the subsections as the issue body. Apply the suggested labels. Link dependencies where noted.**
+
+## Current state (2026-04-20, end of hackathon)
+
+Baseline for every issue below — do not re-plan work already shipped on `main`.
+
+**Mobile (Expo SDK 54, React Native, TypeScript strict):**
+- Voice loop state machine (Armed → Listening → Processing → Speaking) with single-audio-consumer rule enforced
+- Editorial UI shipped: MicCard with concentric rings + halo + bouncing-dot processing + waveform speaking, CalorieRing SVG draw-in, MacroTable, hairline rule-off lists, Wordmark "Sous / AI" hero
+- Cookbook route live: list + open saved recipe + **delete with confirm + optimistic remove**
+- Home screen shows "Open your cookbook" link + busy dots, uses `useFocusEffect` to reset busy state
+- Cook-time measured on cooking screen and sent to `/finalize`, displayed on summary
+
+**Backend (FastAPI on Railway + Supabase hosted DB):**
+- Live at `https://sousai-production.up.railway.app`
+- Endpoints: `POST /sessions`, `POST /utterance`, `POST /finalize`, `GET /recipes/{id}`, `DELETE /recipes/{id}`, `GET /users/{user_id}/recipes`, `GET /tts/stream/{audio_id}`, `GET /healthz`
+- `cook_time_seconds` column on `recipes`, threaded through finalize + list + get-by-id
+- LLM path (module name is `gemini_client` for historical reasons; actual stack is **Groq**): `groq/whisper-large-v3-turbo` for STT, then `groq/llama-3.1-8b-instant` with function-calling for intent classification + ingredient extraction + ack generation + in-loop `get_nutrition` tool call during utterance handling
+- ElevenLabs streaming TTS wired with voice ID `DODLEQrClDo8wCz460ld`
+- Edamam per-ingredient macro lookup called from `/finalize` (separate from the in-utterance tool-call path), with LLM fallback for unresolvable items (flagged `estimated: true`)
+
+**Known rough edges (to inform issues below, not separate to-do's):**
+- Picovoice wake word is code-complete but disabled in demo (no key); tap-to-wake is the only path that ships
+- Demo user is hardcoded UUID `00000000-0000-0000-0000-000000000001`; no real auth
+- Past-tense or narration utterances ("added oil", "adding oil to the pan") classify as small_talk instead of add_ingredient — imperative-only phrasing works reliably
+- Clarification state (`pending_clarification` field) threads correctly in the happy path but has at least one observed case where `is_resolving=False` despite a pending clarification
+
+**Collaboration note (2026-04-20 onward):**
+Post-hackathon, Atharva and Rishi can both edit any file including `backend/gemini_client/`. The git deny rule that blocked Rishi's edits in that directory has been retired. Branch + PR discipline stays on per `CLAUDE.md`.
+
+---
+
+## 1. Build an NLU eval harness before any refactor
+
+**Labels:** `infra`, `testing`, `priority:critical`, `backend`
+**Effort:** 1 evening (~4 hours)
+**Depends on:** nothing — do this first
+
+**Why:** We cannot safely refactor the NLU path, swap models, or change prompts without a reproducible test set. Every other item on this roadmap should run this harness before merge. Without it, we will silently regress classification accuracy on utterances that used to work.
+
+**What to build:**
+- `backend/gemini_client/evals/` directory
+- `utterances.yaml` with 150 labeled cases covering: `add_ingredient` (clear imperative), `add_ingredient` (vague quantities — "splash", "pinch", "handful"), **`add_ingredient` (past-tense / narration — "added oil", "adding oil to the pan", "throwing in some garlic" — these currently misclassify as `small_talk`)**, `question` (substitutions, techniques, timing), `acknowledgment` (responses to prior clarifications), `small_talk`, `finish_recipe`, and the ambiguous cases we've hit during testing
+- Each case has: `utterance_text` (or path to audio fixture), `expected_intent`, `expected_ingredient` (if applicable), `pending_clarification` context (if applicable), `notes`
+- A pytest-based runner: `uv run pytest backend/gemini_client/evals/` prints a scorecard (accuracy per intent, list of failures with diffs)
+- A CI job that runs the eval suite on every PR touching `gemini_client/` or prompt files, fails the build if accuracy drops below a committed baseline
+
+**Acceptance criteria:**
+- [ ] 150+ labeled utterances committed
+- [ ] Runner prints per-intent accuracy and flags regressions against `baseline_scores.json`
+- [ ] Baseline file is committed; any score drop requires explicit baseline update in the PR
+- [ ] README documents how to add a new eval case when a bug is found in production
+
+**Notes for Claude Code:** Start by grepping the existing test suite for any existing utterance fixtures — harvest those first. Then add cases for every edge case named in `docs/design.md` and `CLAUDE.md`. Do NOT generate synthetic utterances with an LLM for the eval set; use real examples from our own testing or write them by hand. Synthetic evals test whether the model agrees with itself, not whether the system works.
+
+---
+
+## 2. Refactor the single-prompt NLU into routed handlers
+
+**Labels:** `refactor`, `backend`, `priority:critical`, `architecture`
+**Effort:** 1 weekend (~12 hours)
+**Depends on:** #1 (eval harness must exist before refactor)
+
+**Why:** The current architecture is one giant Gemini prompt doing intent classification, ingredient extraction, clarification handling, and ack generation in a single call. This does not scale to upcoming features (recipe mode, daily macros, coach mode). A single prompt trying to do planning + routing + extraction + formatting becomes fragile and hard to evolve. We need to split into a small router + focused per-mode handlers.
+
+**What to build:**
+
+Target structure under `backend/gemini_client/`:
+```
+gemini_client/
+├── __init__.py            # exports process_utterance (preserve current signature)
+├── router.py              # classify mode: freestyle | recipe | coach_query | qa
+├── handlers/
+│   ├── freestyle.py       # add_ingredient, acknowledgment intents (current behavior)
+│   ├── qa.py              # question intent, substitution/technique answers
+│   └── small_talk.py      # fallback
+├── prompts/               # each handler's system prompt in a separate .txt file
+├── context.py             # assemble_context(session, mode) — pulls ingredients, pending_clarification
+└── schemas.py             # Pydantic types (already exist, preserve)
+```
+
+Flow:
+1. `process_utterance` is the single entry point (unchanged signature — backward compatible with current FastAPI route)
+2. It calls `router.classify()` — a small, fast Gemini Flash call with a tight 4-way classification prompt OR a heuristic based on session state (if `current_recipe_id` is set, it's recipe mode; etc.)
+3. It calls `context.assemble()` to build the per-mode context bundle
+4. It dispatches to the appropriate handler, each with its own focused system prompt
+5. Handler returns the same `UtteranceResponse` shape we already use
+
+**Acceptance criteria:**
+- [ ] Eval harness from #1 scores ≥ current baseline after refactor (no regression)
+- [ ] Each handler's system prompt is ≤ 40 lines (vs current monolithic prompt)
+- [ ] Router classification is testable independently with its own eval subset
+- [ ] `process_utterance` signature and response shape unchanged — no mobile client changes required
+- [ ] Recipe mode handler is stubbed (returns "recipe mode coming soon" ack) to reserve the routing slot for #6
+
+**Notes for Claude Code:** Do NOT introduce LangGraph, LangChain, or any agent framework in this refactor. Plain Python, plain async functions, plain dispatch. We will revisit orchestration frameworks only after this refactor is stable and we have a clear need. The goal here is structural clarity, not framework adoption.
+
+---
+
+## 3. Upgrade classification model + confidence-based fallback
+
+**Labels:** `reliability`, `backend`, `priority:high`
+**Effort:** 1 afternoon (~4 hours)
+**Depends on:** #1, #2
+
+**Why:** Groq Llama 3.1 8B was the right pick for hackathon latency (sub-second responses). For a real product with users who track macros daily, classification reliability matters more than $0.50/month in API cost. A larger or more capable model is noticeably better on ambiguous cases (past-tense phrasing, vague quantities, implicit intents). Additionally, the model should ask for clarification instead of guessing when it's unsure — the clarification infrastructure exists; we just need to wire in a confidence threshold.
+
+**What to build:**
+- Pick a classifier upgrade and commit to it: options are `groq/llama-3.3-70b-versatile` (same provider, bigger model, minimal migration), `openai/gpt-4.1-mini`, `anthropic/claude-haiku-4.5`, or `gemini-2.5-flash`. Run the #1 eval suite across candidates and pick the best accuracy-per-dollar.
+- Keep the current 8B model for the extraction / tool-call handler where speed matters more than classification quality.
+- Add structured output requesting `confidence: float` (0.0–1.0) alongside each classification.
+- If `confidence < 0.7` on router OR `confidence < 0.75` on ingredient extraction, route to clarification path instead of committing the action.
+- Clarification prompt template: "I want to make sure I got that right — did you mean `<best-guess>` or `<second-guess>`?"
+- Log every low-confidence event to a structured log line so we can tune thresholds empirically.
+
+**Acceptance criteria:**
+- [ ] Classifier upgrade chosen with eval data backing the pick
+- [ ] All LLM calls return structured confidence scores
+- [ ] Low-confidence utterances route to clarification instead of guessing
+- [ ] Threshold values live in a config module, not hardcoded in handlers
+- [ ] Eval harness grows a "confidence calibration" report: on cases we got wrong, what was the confidence?
+
+**Notes for Claude Code:** Thresholds of 0.7/0.75 are starting guesses. The real values come from running evals with confidence logged and picking the threshold that maximizes precision without nuking recall. Include a one-time script that suggests an optimal threshold based on the eval run. Do not assume we're staying on Groq — the eval harness exists precisely to let us swap providers with data, not vibes.
+
+---
+
+## 4. Daily macro tracking with agent-visible running totals
+
+**Labels:** `feature`, `priority:high`, `full-stack`
+**Effort:** 1 weekend (~14 hours)
+**Depends on:** #2 (handlers must exist so we can inject daily-total context cleanly)
+
+**Why:** This is the feature that transforms the app from a single-meal logger into a daily-use tool with compound value. Single-meal tracking is disposable; daily totals against goals is the loop that retains real macro trackers. It also unlocks coach-mode-lite for free: once the agent sees current daily totals and goals, it can naturally surface adjustments without a separate "coach mode" being built.
+
+**What to build:**
+
+Backend:
+- Migration: add `daily_calorie_goal INT`, `daily_protein_goal_g INT`, `daily_fat_goal_g INT`, `daily_carb_goal_g INT` to `profiles` (nullable; no onboarding for now, user edits in a settings screen)
+- View or materialized rollup: `daily_macro_totals(user_id, date, calories, protein_g, fat_g, carbs_g)` aggregating from `macro_logs` joined through `recipes.user_id` and `recipes.finalized_at::date` (the table actually stores `created_at` on both `recipes` and `macro_logs`, but the meaningful day is when the recipe was *finalized*, not when the row was inserted)
+- New route: `GET /daily-macros?date=YYYY-MM-DD` returns today's totals + goals + remaining
+- Context assembly (#2) includes today's totals + goals in every handler's context bundle
+
+Mobile:
+- Home screen widget: stat card showing "1,420 / 2,200 cal · 82g / 150g protein" with a thin ring/bar for each macro
+- Settings screen (new): goal editor, manual numeric inputs, saves to profile
+- Refresh daily-totals on app foreground and after every `/finalize`
+
+Agent behavior:
+- Freestyle handler's system prompt mentions current daily totals — the model can reference them naturally ("heads up, that'll put you at 1,800 cal for the day")
+- Do NOT pre-program coaching behavior. Let the model surface adjustments organically from context; if it's too chatty, constrain via prompt, not via code
+
+**Acceptance criteria:**
+- [ ] Migration applied, daily totals accurate against test data
+- [ ] Home screen shows running daily totals, updates after each finalized recipe
+- [ ] Settings screen allows goal editing, persists to profile
+- [ ] Agent responses reference daily context when relevant (verified via 5+ eval cases)
+- [ ] Feature works across timezone edges (user cooking at 11:45 PM vs 12:15 AM must roll over correctly — use user's local date, not UTC)
+
+**Notes for Claude Code:** Timezone handling is the sneaky bug here. Store the user's timezone on the profile (pull from the device on first launch) and compute "today" in that timezone when rolling up. Do not use UTC midnight.
+
+---
+
+## 5. Self-use and private beta (7-day soak test)
+
+**Labels:** `product`, `priority:high`, `qa`
+**Effort:** 2 weeks of calendar time, ~4 hours of engineering to set up
+**Depends on:** #4 — don't beta without daily macros, the app isn't retention-shaped yet without them
+
+**Why:** We have no real-world signal on this product. Before App Store deployment (#8), we need to know what breaks when a motivated user cooks with it daily for a week. The author using it personally for 7 consecutive days is the minimum bar; getting 5–10 macro-tracking friends on TestFlight is the real bar.
+
+**What to build:**
+- TestFlight pipeline: `eas build --profile preview` configured, submission workflow documented in `docs/testflight.md`
+- Feedback channel: a `/feedback` endpoint + minimal in-app "Report an issue" surface that posts to a Supabase `feedback` table (text, session_id, timestamp, device_info)
+- Crash reporting: Sentry free tier wired into the mobile app and backend
+- A weekly digest script: summarizes feedback + crashes + usage metrics for review
+
+**Acceptance criteria:**
+- [ ] TestFlight build submitted and reviewed
+- [ ] 5+ external users installed, each with >3 completed recipes in 7 days
+- [ ] Feedback/crash data flowing to a dashboard we actually look at
+- [ ] A prioritized bug list emerges from the soak test, becomes input to #7
+
+**Notes for Claude Code:** This is not mostly an engineering task — it's a product task with engineering scaffolding. The engineering is ~4 hours (Sentry, feedback endpoint, TestFlight config). The rest is calendar time while users actually use the app. Do not skip the calendar time by declaring it "done" after the infrastructure is up.
+
+---
+
+## 6. Recipe assistance mode
+
+**Labels:** `feature`, `priority:high`, `full-stack`
+**Effort:** 1 weekend (~14 hours)
+**Depends on:** #2 (recipe handler slot already stubbed), #4 (daily macro context for the final summary)
+
+**Why:** This is the feature that differentiates sous.ai from "a voice UI on top of MyFitnessPal." No other app has a voice assistant that guides you through a recipe AND tracks what you actually cooked (with deviations). The deviation-tracking is the killer feature: if the recipe says "2 tbsp butter" and the user says "a splash of butter," we track the delta and adjust macros — something no recipe app does today.
+
+**What to build:**
+
+Backend:
+- Migration: `recipes.source_url` (nullable), `recipes.steps` (JSONB array of `{index, instruction, expected_ingredients}`), `recipes.mode` (`'freestyle' | 'guided'`)
+- New route: `POST /recipes/import { url }` — fetches page, uses Gemini to parse into structured ingredients + steps
+- New route: `POST /recipes/:id/advance-step` — increments current step, returns next instruction
+- Recipe handler (replace stub from #2): handles "what's next", "repeat that", "I added X instead" utterances with current-step context
+
+Mobile:
+- Recipe import screen: URL paste input, shows parsed recipe preview
+- Recipe mode UI: step-by-step card replaces the freestyle ingredient card, shows current step, progress indicator, deviation log
+- Voice commands: "what's next", "repeat", "go back", "I added X instead of Y" — all route to recipe handler
+
+Deviation handling:
+- When user reports a deviation ("used 1 tbsp instead of 2"), log it to `ingredients` with a `deviation_from` reference
+- Final macro calculation uses actual ingredients as-cooked, not recipe-as-written
+
+**Acceptance criteria:**
+- [ ] URL import works on 5 major recipe sites (NYT Cooking, AllRecipes, Serious Eats, Food Network, BBC Good Food)
+- [ ] Step-by-step voice guidance progresses correctly via voice commands
+- [ ] Deviation tracking reflected in final macros (demo: cook a recipe with 2 deliberate deviations, verify macros differ from recipe-as-written)
+- [ ] Recipe mode coexists with freestyle mode — router correctly dispatches based on session state
+- [ ] Eval suite extended with 30+ recipe-mode utterances
+
+**Notes for Claude Code:** For URL parsing, try schema.org Recipe microdata first (most major recipe sites publish it) — falls back to Gemini only if parsing fails. This saves LLM cost and gives more reliable structured data for the sites that support it.
+
+---
+
+## 7. Fix top issues surfaced by the 7-day soak test
+
+**Labels:** `bug`, `priority:high`
+**Effort:** 1 weekend (~12 hours)
+**Depends on:** #5
+
+**Why:** Don't ship to the App Store with known issues from beta. The specific bugs cannot be listed yet (they depend on what users surface), but the work slot is reserved.
+
+**What to build:**
+- Review all feedback and crash reports from #5
+- Prioritize: classification accuracy issues → UI bugs → feature gaps → polish
+- Fix the top 5–7 issues, triage the rest into backlog
+
+**Acceptance criteria:**
+- [ ] All P0/P1 bugs from beta are closed
+- [ ] Eval suite updated with any utterances that failed in production
+- [ ] No regressions — full test + eval suite green
+
+---
+
+## 7.5. Real multi-user authentication
+
+**Labels:** `feature`, `priority:critical`, `full-stack`, `security`
+**Effort:** 1 weekend (~12 hours)
+**Depends on:** #7 (don't break auth mid-beta), blocks #8 (App Store won't pass a hardcoded-user app)
+
+**Why:** The entire app currently runs as a single seeded UUID `00000000-0000-0000-0000-000000000001`. Every user would see every other user's cookbook. This is the one issue that absolutely cannot ship to the App Store. Supabase already has an auth layer; it's just unused.
+
+**What to build:**
+
+Backend:
+- Enable Supabase Row-Level Security on `profiles`, `recipes`, `ingredients`, `macro_logs`. Policies: users can only read/write rows where `user_id = auth.uid()`.
+- FastAPI: accept a `Authorization: Bearer <supabase_jwt>` header, verify it with Supabase's public JWKS, populate a `current_user_id` dependency
+- Replace every route's `user_id` source from the hardcoded UUID to `Depends(current_user_id)`
+- Delete or gate the seeded demo user path behind an env flag for local development only
+
+Mobile:
+- Sign-in screen using Supabase Auth (start with email magic-link or OAuth; Apple Sign-In is required for App Store anyway — lead with that)
+- Store the JWT in `expo-secure-store`, refresh on foreground
+- Attach the JWT to every backend fetch via a shared client wrapper
+- Sign-out flow in a settings screen
+
+Migration:
+- For any existing seeded demo data, either delete on first real login or stash it behind a "demo" flag
+
+**Acceptance criteria:**
+- [ ] New users can sign up, sign in, sign out
+- [ ] RLS verified — user A's cookbook is invisible to user B (automated test against real Supabase)
+- [ ] All routes enforce auth; unauthenticated requests return 401
+- [ ] Apple Sign-In works and is the primary method (App Store requirement if any third-party auth exists)
+- [ ] Session persists across app restarts; refresh tokens handled
+
+**Notes for Claude Code:** This is the only issue in the roadmap where RLS policies are as important as the route code. Write the Supabase policies as SQL migrations (not via dashboard), test them with a pytest suite that spins up two user contexts and verifies isolation. Do not rely on "the backend will check" — RLS is the real security boundary.
+
+---
+
+## 8. App Store submission
+
+**Labels:** `release`, `priority:medium`, `infra`
+**Effort:** 1 weekend (~14 hours, mostly non-code)
+**Depends on:** #7, **#7.5 (auth must ship before submission)**
+
+**Why:** Get the app to real users beyond TestFlight. App Store credibility is a non-trivial signal for a portfolio project — "shipped on App Store with N users" on a resume reads differently than "TestFlight beta."
+
+**What to build:**
+- Privacy policy: hosted page describing what we record, what we send to Gemini, what we retain (raw audio NOT retained beyond the request; transcriptions stored in DB; macro data stored indefinitely)
+- App Store metadata: description, keywords, screenshots (6.7" and 6.1" iPhone), preview video (30 sec)
+- App Store privacy questionnaire: voice/mic is sensitive — be specific and honest, specifically that voice is transcribed via Gemini and raw audio is not retained
+- Cost guardrails: add rate limiting per-user per-day so a single user cannot burn through Gemini/ElevenLabs quotas — essential before any public install
+- Monetization decision: document whether v1 is free/ads/subscription/one-time — even if the answer is "free with usage limits," write it down
+
+**Acceptance criteria:**
+- [ ] App approved and live on App Store
+- [ ] Privacy policy hosted and linked from app + App Store listing
+- [ ] Per-user rate limits enforced (max N utterances/day, configurable)
+- [ ] Cost per active user per day calculated and documented (target <$0.20)
+
+**Notes for Claude Code:** Apple's most common rejection for voice apps is insufficient disclosure of what happens to recorded audio. Err on the side of being over-specific in the privacy policy. Include the explicit sentence "Raw audio is sent to Google Gemini for transcription and is not retained by our servers beyond the duration of the request."
+
+---
+
+## 9. Cookbook search, filter, and richer recipe management
+
+**Labels:** `feature`, `priority:medium`, `mobile`, `backend`
+**Effort:** 1 weekend (~10 hours)
+**Depends on:** #6 (cookbook becomes much more valuable once it contains guided-cook recipes)
+
+**Why:** The cookbook already lists saved recipes with name / calories / cook-time / finalized-at / delete (shipped at hackathon). The missing pieces are search, filter, and edit — the features that turn recipe history into personal data with compound retention value. Filter by ingredient ("what have I made with chicken?"), by date range, by macro range ("high-protein meals under 600 cal"), by cook-time range.
+
+**What to build (on top of the existing `/users/{user_id}/recipes` endpoint and cookbook route):**
+- Backend: full-text search on recipe name + ingredient names (Postgres `tsvector` indexed). Extend the list endpoint to accept `q`, `ingredient`, `max_calories`, `min_protein`, `from_date`, `to_date` query params.
+- Mobile: search bar at the top of the cookbook route, with debounced input
+- Mobile: filter drawer with macro range sliders, date picker, ingredient chips
+- Mobile: recipe detail screen — full ingredient list, macros, notes, delete (already exists), **rename**, **add notes** (new text field `recipes.notes`)
+- Backend: `PATCH /recipes/{id}` accepting `recipe_name` and `notes` updates
+
+**Acceptance criteria:**
+- [ ] Search returns results in <200ms on a library of 500 recipes
+- [ ] Filters compose (date + macro + ingredient simultaneously)
+- [ ] Rename + notes persist across sessions
+- [ ] Existing delete flow preserved (already has confirm dialog)
+
+---
+
+## 10. Barcode scanning for packaged ingredients
+
+**Labels:** `feature`, `priority:medium`, `mobile`
+**Effort:** 1 day (~8 hours)
+**Depends on:** nothing (can parallelize)
+
+**Why:** "A scoop of protein powder" is inherently imprecise. For users actually hitting macro targets, scanning the label is strictly better. This is also the demo feature that makes the app feel modern — judges at a hypothetical future demo would react to a camera-based ingredient entry much more than to voice-only.
+
+**What to build:**
+- `expo-camera` integration for barcode scanning (UPC/EAN)
+- Lookup via Open Food Facts API (free, no API key needed, wide coverage)
+- When scanned, add to ingredient list as a structured item with per-serving macros already resolved — skips Edamam for this ingredient entirely
+- Voice command: "I'm adding a scoop" after a scan — uses the scanned item's serving size
+
+**Acceptance criteria:**
+- [ ] Camera scans UPC/EAN barcodes reliably
+- [ ] Open Food Facts lookup returns macros for 80%+ of common US grocery items
+- [ ] Scanned ingredients appear in the cooking session alongside voice-entered ingredients
+- [ ] Fallback flow when item is not in OFF: prompt user to enter macros manually once, cache for future
+
+---
+
+## 11. Shareable recipe pages
+
+**Labels:** `feature`, `priority:medium`, `growth`, `backend`
+**Effort:** 1 day (~8 hours)
+**Depends on:** #6 (recipes need to be structured enough to render publicly)
+
+**Why:** Each finalized recipe gets a public URL. Cooking becomes slightly social (light retention hook) and every shared link is an organic growth vector. Simple to build, high optionality payoff.
+
+**What to build:**
+- `recipes.is_public` boolean, toggled by user from recipe detail screen
+- Public-facing Next.js or simple static page at `https://sous.ai/r/<recipe_id>` (separate small deployment, not in the mobile app)
+- Open Graph tags so link previews look good in iMessage, Twitter, Reddit
+- "Cook this with Sous" CTA on the public page, links to App Store
+
+**Acceptance criteria:**
+- [ ] Public recipe page renders with ingredients, macros, notes
+- [ ] OG image auto-generated from recipe data (can be a simple template, not a hero image)
+- [ ] Privacy: private recipes never render publicly, even if someone guesses the URL
+- [ ] CTA drives App Store link with attribution query param so we can measure share-driven installs
+
+---
+
+## 12. Apple Health integration
+
+**Labels:** `feature`, `priority:medium`, `mobile`
+**Effort:** 1 afternoon (~4 hours)
+**Depends on:** #4
+
+**Why:** Serious fitness users already track via Apple Health. Writing our macros there is a trust signal that we're integrating into their existing workflow, not trying to replace it. Low effort, high perceived value for the audience we care about.
+
+**What to build:**
+- `react-native-health` integration
+- Permission flow on first finalize after update
+- Write calories, protein, fat, carbs to HealthKit dietary category on every `/finalize`
+- Settings toggle to disable
+
+**Acceptance criteria:**
+- [ ] Permission flow works, respects user denial
+- [ ] Macros appear in Apple Health Nutrition tab after cooking
+- [ ] Values are attributed to Sous Chef as the source app
+
+---
+
+## 13. Photo-based pantry / meal suggestion
+
+**Labels:** `feature`, `priority:low`, `full-stack`
+**Effort:** 1 weekend (~12 hours)
+**Depends on:** #6
+
+**Why:** Snap a photo of your fridge, get recipe suggestions based on what's there. This is the demo feature that would have landed the hackathon outcome differently — genuinely impressive-looking multimodal AI use. Low priority for users, high priority for pitch/portfolio visibility.
+
+**What to build:**
+- Camera capture + a multimodal vision call to identify visible ingredients. Groq does not offer vision models today, so this issue adds a second LLM dependency. Candidates: `gemini-2.5-flash` (cheapest), `openai/gpt-4o-mini`, `anthropic/claude-haiku-4.5`. Evaluate on 20 fridge photos before committing.
+- Recipe suggestion: given identified ingredients + user's daily macro gap (#4) + recipe history, suggest 3 recipes
+- One-tap: "Cook this" kicks off guided recipe mode (#6)
+
+**Acceptance criteria:**
+- [ ] Photo capture flow works reliably
+- [ ] Vision model correctly identifies 80%+ of common fridge contents on a 20-photo test set
+- [ ] Suggestions are contextual to user's goals and history, not generic
+- [ ] New API key managed through the same secrets flow as the others (Railway env + `pydantic-settings`)
+
+---
+
+## 14. Revisit orchestration framework decision
+
+**Labels:** `architecture`, `priority:low`, `research`
+**Effort:** 1 day of evaluation, 1 weekend of migration if triggered
+**Depends on:** #6 is complete and stable
+
+**Why:** After #2, #4, and #6 are shipped, we'll have three handlers plus routing plus tool use. If the handler boilerplate has gotten repetitive, or if state transitions between modes are complex enough that explicit graph modeling would help, evaluate LangGraph (or Pydantic AI as a lighter alternative). If plain Python still reads clean, do nothing.
+
+**What to build:**
+- Write a one-page evaluation document: what specific pain are we feeling that a framework would solve? What's the migration cost? What do we give up?
+- If migration is justified, do a spike on one handler to de-risk before committing
+- Decision gate: either commit to migration, or commit to staying on plain Python for the foreseeable future and document why
+
+**Acceptance criteria:**
+- [ ] Written decision with rationale
+- [ ] If migrating: spike complete and full migration plan exists
+- [ ] If not migrating: explicit call-out in CLAUDE.md so future Claude instances don't re-litigate
+
+**Notes for Claude Code:** This is a decision point, not an automatic upgrade. Plain Python handlers serve us well right now and the cost of a framework comes due every time we debug through an additional abstraction layer. The default answer is "no framework" unless the pain is specific and describable.
+
+---
+
+## Dependency graph (quick reference)
+
+```
+#1 eval harness ─┬─> #2 refactor handlers ─┬─> #3 confidence + Pro
+                 │                          │
+                 │                          ├─> #4 daily macros ──> #5 beta ──> #7 fixes ──> #7.5 auth ──> #8 App Store
+                 │                          │                                                                │
+                 │                          └─> #6 recipe mode ───────────────────────────────────────────> │
+                 │                                                  │                                        │
+                 │                                                  └─> #9 cookbook search                   │
+                 │                                                  └─> #11 shareable                        │
+                 │                                                  └─> #13 photo pantry                     │
+                 │                                                                                           │
+                 │                              #10 barcode (parallel) ────────────────────────────────────> │
+                 │                              #12 Apple Health (after #4) ────────────────────────────────>│
+                 │
+                 └─> #14 framework revisit (after #6)
+```
+
+#7.5 gates #8 absolutely. Every other edge is a "should precede" not a hard block.
+
+## Labels to create in the repo
+
+If not already present:
+- `priority:critical`, `priority:high`, `priority:medium`, `priority:low`
+- `feature`, `refactor`, `bug`, `infra`, `testing`, `release`, `research`
+- `backend`, `mobile`, `full-stack`
+- `architecture`, `reliability`, `growth`, `qa`, `product`


### PR DESCRIPTION
## What

Documentation-only PR that captures the post-hackathon transition of the repo. No code changes.

- **Root `CLAUDE.md`** — drops the 36-hour hackathon framing, the phase-gate branching rule ("turns on once Atharva clones"), and the hard ownership boundary on `backend/gemini_client/`. Replaces with: strict branching always on, free-for-all on issues, integration-checker as a standard subagent. The "Atharva owns" rule was partially retired in 691aea6; this finishes the cleanup.
- **`docs/sous-ai-roadmap.md`** — prioritized post-hackathon work, ordered high-impact to low. Each `##` section is sized to become one GitHub issue (the next PR uses this). Documents the current shipped state and known rough edges (past-tense classification, hardcoded demo user UUID, Picovoice disabled in demo, etc.).
- **`docs/notes/2026-04-19-readme-prompt.md`** — the prompt used to generate the hackathon README in a fresh Claude Code plan session. Saved so it can be re-run or adapted.
- **`docs/notes/2026-04-20-issue-creation-prompt.md`** — the prompt used to turn the roadmap into GitHub issues via `gh`.

## Why

Independent of #36 (gemini_client refactor); these were sitting in the working tree as the working state moved from hackathon-mode to production-push. Splitting them into their own PR keeps #36 focused on the refactor and lets this land (or not) on its own merits. Either ordering is safe — no file overlap.

## How to test

Read-only PR; nothing to run. Sanity checks worth eyeballing:

- `CLAUDE.md` diff lines up with the project memory in `.claude/memory/project_production_push.md` and the current state of `backend/gemini_client/CLAUDE.md`.
- `docs/sous-ai-roadmap.md` lists the same baselined regression buckets that `backend/gemini_client/evals/baseline_scores.json` knows about.

## Checklist

- [x] No code changes; tests not applicable
- [x] Smoke test not required (no runtime change)
- [x] No `.env` in diff; no new env vars
- [x] API contract unchanged (no API touched)
- [x] Rebased on `origin/main` (not merged)
- [x] `CLAUDE.md` updated — that's literally the PR
- [x] (PR template's stale "no edits under `backend/gemini_client/` unless you are Atharva" line — that rule is what this PR retires.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)