### PR TITLE
feat(gemini_client): confidence scoring + disambiguation clarification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,10 @@ GROQ_API_KEY=
 # iterating against Ollama (no rate limit).
 # EVAL_RATE_LIMIT_DELAY=1.5
 
+# Some local models (e.g. Ollama llama3:8b) 400 on tools=[...]. Set to 1 to
+# skip the Edamam tool call in the freestyle handler. Production runs without.
+# LLM_TOOLS_DISABLED=1
+
 # ElevenLabs — https://elevenlabs.io/app/settings/api-keys
 ELEVENLABS_API_KEY=
 # Pick a voice from https://elevenlabs.io/app/voice-lab and paste the voice_id:

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,24 @@
 # Used for utterance processing (llama-3.1-8b-instant) and audio transcription (whisper-large-v3-turbo)
 GROQ_API_KEY=
 
+# --- LLM client overrides (optional) -----------------------------------------
+# All four are read by gemini_client/config.py. Defaults preserve Groq+8B prod.
+# Set these to point the eval harness at a local Ollama for fast iteration.
+# LLM_BASE_URL must NOT end in /v1 — see backend/gemini_client/evals/README.md.
+# LLM_BASE_URL=http://localhost:11434
+# LLM_API_KEY=ollama
+# LLM_MODEL=llama3:8b
+
+# Confidence thresholds for the disambiguation router. Below these, the
+# pipeline asks the user to clarify instead of guessing. Tuned via
+# `uv run python -m gemini_client.evals.suggest_thresholds`.
+# LLM_ROUTER_CONFIDENCE_THRESHOLD=0.7
+# LLM_FREESTYLE_CONFIDENCE_THRESHOLD=0.75
+
+# Eval-only: per-test sleep that protects the Groq free tier. Set to 0 when
+# iterating against Ollama (no rate limit).
+# EVAL_RATE_LIMIT_DELAY=1.5
+
 # ElevenLabs — https://elevenlabs.io/app/settings/api-keys
 ELEVENLABS_API_KEY=
 # Pick a voice from https://elevenlabs.io/app/voice-lab and paste the voice_id:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 **/.env.local
 **/.env.*.local
 
+# Eval measurement artifact (regenerated on every run; not source)
+**/eval_results.json
+**/baseline_scores.proposed.json
+
 # Python
 **/.venv/
 **/__pycache__/

--- a/backend/app/routes/utterance.py
+++ b/backend/app/routes/utterance.py
@@ -114,6 +114,8 @@ async def process_utterance_endpoint(
     # Low-confidence disambiguation takes precedence: the model attached a
     # disambiguation marker, so persist the matching sentinel and skip the
     # usual ingredient/question branching (items will be empty for these).
+    # The threshold check happened upstream in gemini_client; this branch
+    # trusts the marker — if it's set, a clarification is warranted.
     if result.disambiguation is not None:
         if result.disambiguation.kind == "router":
             new_pending = _encode_router_disambig(

--- a/backend/app/routes/utterance.py
+++ b/backend/app/routes/utterance.py
@@ -14,10 +14,20 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _INGREDIENT_PREFIX = "INGREDIENT_CLARIFICATION:"
+_ROUTER_DISAMBIG_PREFIX = "ROUTER_DISAMBIG:"
+_EXTRACTION_DISAMBIG_PREFIX = "EXTRACTION_DISAMBIG:"
 
 
 def _encode_ingredient_clarification(name: str, question: str) -> str:
     return f"{_INGREDIENT_PREFIX}{name}|{question}"
+
+
+def _encode_router_disambig(best: str, second: str, question: str) -> str:
+    return f"{_ROUTER_DISAMBIG_PREFIX}{best}|{second}|{question}"
+
+
+def _encode_extraction_disambig(best: str, second: str, question: str) -> str:
+    return f"{_EXTRACTION_DISAMBIG_PREFIX}{best}|{second}|{question}"
 
 
 def _decode_pending(pending: str | None) -> tuple[str, str | None]:
@@ -25,12 +35,26 @@ def _decode_pending(pending: str | None) -> tuple[str, str | None]:
         body = pending[len(_INGREDIENT_PREFIX):]
         name, _, _ = body.partition("|")
         return "ingredient", name
+    if pending and pending.startswith(_ROUTER_DISAMBIG_PREFIX):
+        return "router_disambig", None
+    if pending and pending.startswith(_EXTRACTION_DISAMBIG_PREFIX):
+        return "extraction_disambig", None
     return "question", None
 
 
 def _pending_display_text(pending: str) -> str:
     if pending.startswith(_INGREDIENT_PREFIX):
         _, _, question = pending.partition("|")
+        return question
+    if pending.startswith(_ROUTER_DISAMBIG_PREFIX):
+        body = pending[len(_ROUTER_DISAMBIG_PREFIX):]
+        _, _, rest = body.partition("|")
+        _, _, question = rest.partition("|")
+        return question
+    if pending.startswith(_EXTRACTION_DISAMBIG_PREFIX):
+        body = pending[len(_EXTRACTION_DISAMBIG_PREFIX):]
+        _, _, rest = body.partition("|")
+        _, _, question = rest.partition("|")
         return question
     return pending
 
@@ -60,6 +84,14 @@ async def process_utterance_endpoint(
     pending_kind, clarification_name = _decode_pending(pending_clarification)
     llm_pending = _pending_display_text(pending_clarification) if pending_clarification else None
 
+    # Router-disambig replies should re-classify from scratch — the user has
+    # picked a mode, so we clear the pending hint and let the router run on
+    # the new utterance. Extraction-disambig replies keep llm_pending so the
+    # freestyle prompt's "Disambiguation replies" section can interpret the
+    # chosen option.
+    if pending_kind == "router_disambig":
+        llm_pending = None
+
     ingredients_resp = db.table("ingredients").select("*").eq("recipe_id", session_id).execute()
     session_ingredients = [_db_row_to_ingredient(r) for r in (ingredients_resp.data or [])]
 
@@ -79,7 +111,36 @@ async def process_utterance_endpoint(
     new_pending: str | None = None
     tts_ack = result.ack  # may be overridden below when a clarification question is synthesized
 
-    if result.intent == Intent.add_ingredient and result.items:
+    # Low-confidence disambiguation takes precedence: the model attached a
+    # disambiguation marker, so persist the matching sentinel and skip the
+    # usual ingredient/question branching (items will be empty for these).
+    if result.disambiguation is not None:
+        if result.disambiguation.kind == "router":
+            new_pending = _encode_router_disambig(
+                result.disambiguation.best,
+                result.disambiguation.second,
+                result.ack,
+            )
+            logger.info(
+                "router_disambig | best=%s second=%s ack=%r",
+                result.disambiguation.best,
+                result.disambiguation.second,
+                result.ack,
+            )
+        else:  # extraction
+            new_pending = _encode_extraction_disambig(
+                result.disambiguation.best,
+                result.disambiguation.second,
+                result.ack,
+            )
+            logger.info(
+                "extraction_disambig | best=%s second=%s ack=%r",
+                result.disambiguation.best,
+                result.disambiguation.second,
+                result.ack,
+            )
+        db.table("recipes").update({"pending_clarification": new_pending}).eq("recipe_id", session_id).execute()
+    elif result.intent == Intent.add_ingredient and result.items:
         is_resolving = pending_kind == "ingredient" and clarification_name is not None
         logger.info("clarification | is_resolving=%s clarification_name=%s", is_resolving, clarification_name)
 

--- a/backend/gemini_client/_groq.py
+++ b/backend/gemini_client/_groq.py
@@ -7,11 +7,11 @@ the agentic chat-completions retry+tool-call loop, and JSON extraction.
 import asyncio
 import json
 import logging
-import os
 from typing import Any
 
 from groq import AsyncGroq, RateLimitError
 
+from . import config
 from .nutrition_tool import dispatch_tool_call
 
 log = logging.getLogger(__name__)
@@ -22,7 +22,10 @@ _client: AsyncGroq | None = None
 def get_client() -> AsyncGroq:
     global _client
     if _client is None:
-        _client = AsyncGroq(api_key=os.environ["GROQ_API_KEY"])
+        kwargs: dict[str, Any] = {"api_key": config.LLM_API_KEY}
+        if config.LLM_BASE_URL:
+            kwargs["base_url"] = config.LLM_BASE_URL
+        _client = AsyncGroq(**kwargs)
     return _client
 
 
@@ -38,7 +41,7 @@ async def chat_with_tools(
     messages: list[dict],
     *,
     tools: list[dict] | None = None,
-    model: str = "llama-3.1-8b-instant",
+    model: str | None = None,
     temperature: float = 0.1,
     max_tool_iterations: int = 5,
 ) -> str:
@@ -49,13 +52,14 @@ async def chat_with_tools(
     results into `messages` and re-calls.
     """
     client = get_client()
+    resolved_model = model or config.LLM_MODEL
     log.info("groq input | messages=%s", json.dumps(messages, ensure_ascii=False))
 
     for _ in range(max_tool_iterations):
         for attempt in range(4):
             try:
                 kwargs: dict[str, Any] = {
-                    "model": model,
+                    "model": resolved_model,
                     "messages": messages,
                     "temperature": temperature,
                 }

--- a/backend/gemini_client/_groq.py
+++ b/backend/gemini_client/_groq.py
@@ -23,7 +23,8 @@ _client: AsyncGroq | None = None
 class _OpenAIPathRewriteTransport(httpx.AsyncHTTPTransport):
     """Rewrites the Groq SDK's /openai/v1/... path to /v1/... so the same
     SDK can talk to a local OpenAI-compatible server (e.g. Ollama) without
-    pulling in a second SDK. No-op against api.groq.com.
+    pulling in a second SDK. Only attached when LLM_BASE_URL points to a
+    non-Groq host — Groq's own endpoint requires the /openai/v1/ prefix.
     """
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
@@ -39,7 +40,11 @@ def get_client() -> AsyncGroq:
         kwargs: dict[str, Any] = {"api_key": config.LLM_API_KEY}
         if config.LLM_BASE_URL:
             kwargs["base_url"] = config.LLM_BASE_URL
-            kwargs["http_client"] = httpx.AsyncClient(transport=_OpenAIPathRewriteTransport())
+            # The path-rewrite transport only makes sense for non-Groq backends
+            # (Groq itself requires /openai/v1/). Skip it if the user explicitly
+            # set LLM_BASE_URL=https://api.groq.com — otherwise Groq would 404.
+            if "api.groq.com" not in config.LLM_BASE_URL:
+                kwargs["http_client"] = httpx.AsyncClient(transport=_OpenAIPathRewriteTransport())
         _client = AsyncGroq(**kwargs)
     return _client
 

--- a/backend/gemini_client/_groq.py
+++ b/backend/gemini_client/_groq.py
@@ -9,6 +9,7 @@ import json
 import logging
 from typing import Any
 
+import httpx
 from groq import AsyncGroq, RateLimitError
 
 from . import config
@@ -19,12 +20,26 @@ log = logging.getLogger(__name__)
 _client: AsyncGroq | None = None
 
 
+class _OpenAIPathRewriteTransport(httpx.AsyncHTTPTransport):
+    """Rewrites the Groq SDK's /openai/v1/... path to /v1/... so the same
+    SDK can talk to a local OpenAI-compatible server (e.g. Ollama) without
+    pulling in a second SDK. No-op against api.groq.com.
+    """
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        if request.url.path.startswith("/openai/v1/"):
+            new_path = "/v1/" + request.url.path[len("/openai/v1/"):]
+            request.url = request.url.copy_with(path=new_path)
+        return await super().handle_async_request(request)
+
+
 def get_client() -> AsyncGroq:
     global _client
     if _client is None:
         kwargs: dict[str, Any] = {"api_key": config.LLM_API_KEY}
         if config.LLM_BASE_URL:
             kwargs["base_url"] = config.LLM_BASE_URL
+            kwargs["http_client"] = httpx.AsyncClient(transport=_OpenAIPathRewriteTransport())
         _client = AsyncGroq(**kwargs)
     return _client
 

--- a/backend/gemini_client/client.py
+++ b/backend/gemini_client/client.py
@@ -3,20 +3,50 @@
 Receives raw audio (or text), classifies the mode via the hybrid router,
 dispatches to the matching handler, post-processes the response, and
 returns an UtteranceResponse for the FastAPI utterance route.
+
+If the router self-reports confidence below the configured threshold,
+this layer short-circuits the handler call and returns a disambiguation
+question ("Did you mean to add an ingredient or ask a question?")
+instead of guessing. The route layer detects the response's
+`disambiguation` field and persists the pending state.
 """
 
 import logging
 
 from dotenv import find_dotenv, load_dotenv
 
-from . import _groq, postprocess, router
+from . import _groq, config, postprocess, router
 from .context import assemble_context
 from .handlers import HANDLERS, HandlerInput
-from .schemas import ParsedIngredient, UtteranceResponse
+from .router import Mode
+from .schemas import Disambiguation, Intent, ParsedIngredient, UtteranceResponse
 
 log = logging.getLogger(__name__)
 
 load_dotenv(find_dotenv())
+
+
+_MODE_LABELS: dict[Mode, str] = {
+    Mode.freestyle: "add an ingredient",
+    Mode.qa: "ask a cooking question",
+    Mode.small_talk: "just chat",
+    Mode.recipe: "follow a recipe",
+}
+
+
+def _compose_router_disambig(best: Mode, second: Mode) -> str:
+    return f"Did you mean to {_MODE_LABELS[best]} or {_MODE_LABELS[second]}?"
+
+
+def _log_low_confidence(transcript: str, source: str, confidence: float, best: str, second: str | None) -> None:
+    log.info(
+        "low_confidence_event | source=%s transcript=%r confidence=%.3f best=%s second=%s",
+        source,
+        transcript,
+        confidence,
+        best,
+        second,
+    )
 
 
 async def process_utterance(
@@ -43,6 +73,35 @@ async def process_utterance(
         spoken_text,
     )
 
+    # Router-level disambiguation: if the LLM router was below threshold and
+    # named a runner-up, ask the user to choose instead of dispatching the
+    # wrong handler. Heuristic short-circuits (confidence=None) skip this.
+    if (
+        classification.source == "llm"
+        and classification.confidence is not None
+        and classification.confidence < config.ROUTER_CONFIDENCE_THRESHOLD
+        and classification.second_choice is not None
+    ):
+        question = _compose_router_disambig(classification.mode, classification.second_choice)
+        _log_low_confidence(
+            spoken_text,
+            "router_llm",
+            classification.confidence,
+            classification.mode.value,
+            classification.second_choice.value,
+        )
+        return UtteranceResponse(
+            intent=Intent.acknowledgment,
+            ack=question,
+            confidence=classification.confidence,
+            source="router_llm",
+            disambiguation=Disambiguation(
+                kind="router",
+                best=classification.mode.value,
+                second=classification.second_choice.value,
+            ),
+        )
+
     handler_input = HandlerInput(
         transcript=spoken_text,
         context_str=assemble_context(session_ingredients, pending_clarification),
@@ -52,4 +111,18 @@ async def process_utterance(
 
     parsed = await HANDLERS[classification.mode](handler_input)
     postprocess.apply(parsed)
-    return UtteranceResponse.model_validate(parsed)
+    response = UtteranceResponse.model_validate(parsed)
+
+    # Surface low-confidence handler events to the structured log so they're
+    # reviewable independent of whether the handler itself opted to compose
+    # a disambiguation question (commit 6 wires that on freestyle).
+    if (
+        response.confidence is not None
+        and response.confidence < config.FREESTYLE_CONFIDENCE_THRESHOLD
+        and response.source == "freestyle_llm"
+    ):
+        best = response.disambiguation.best if response.disambiguation else response.intent.value
+        second = response.disambiguation.second if response.disambiguation else None
+        _log_low_confidence(spoken_text, response.source, response.confidence, best, second)
+
+    return response

--- a/backend/gemini_client/client.py
+++ b/backend/gemini_client/client.py
@@ -113,13 +113,15 @@ async def process_utterance(
     postprocess.apply(parsed)
     response = UtteranceResponse.model_validate(parsed)
 
-    # Surface low-confidence handler events to the structured log so they're
-    # reviewable independent of whether the handler itself opted to compose
-    # a disambiguation question (commit 6 wires that on freestyle).
+    # Surface low-confidence handler events from any LLM-backed handler.
+    # Threshold is the freestyle one for now (the only handler we route on);
+    # qa_llm / small_talk_llm log purely for observability — operators can
+    # spot a hallucinating qa response from the structured log without
+    # the disambiguation flow firing.
     if (
         response.confidence is not None
+        and response.source is not None
         and response.confidence < config.FREESTYLE_CONFIDENCE_THRESHOLD
-        and response.source == "freestyle_llm"
     ):
         best = response.disambiguation.best if response.disambiguation else response.intent.value
         second = response.disambiguation.second if response.disambiguation else None

--- a/backend/gemini_client/client.py
+++ b/backend/gemini_client/client.py
@@ -29,12 +29,19 @@ async def process_utterance(
     except UnicodeDecodeError:
         spoken_text = await _groq.transcribe(audio_bytes)
 
-    mode = await router.classify(
+    classification = await router.classify(
         transcript=spoken_text,
         session_ingredients=session_ingredients,
         pending_clarification=pending_clarification,
     )
-    log.info("router | mode=%s transcript=%r", mode.value, spoken_text)
+    log.info(
+        "router | mode=%s confidence=%s source=%s second=%s transcript=%r",
+        classification.mode.value,
+        classification.confidence,
+        classification.source,
+        classification.second_choice.value if classification.second_choice else None,
+        spoken_text,
+    )
 
     handler_input = HandlerInput(
         transcript=spoken_text,
@@ -43,6 +50,6 @@ async def process_utterance(
         session_ingredients=session_ingredients,
     )
 
-    parsed = await HANDLERS[mode](handler_input)
+    parsed = await HANDLERS[classification.mode](handler_input)
     postprocess.apply(parsed)
     return UtteranceResponse.model_validate(parsed)

--- a/backend/gemini_client/config.py
+++ b/backend/gemini_client/config.py
@@ -17,6 +17,13 @@ LLM_BASE_URL: str | None = os.environ.get("LLM_BASE_URL") or None
 LLM_API_KEY: str = os.environ.get("LLM_API_KEY") or os.environ.get("GROQ_API_KEY", "")
 LLM_MODEL: str = os.environ.get("LLM_MODEL", "llama-3.1-8b-instant")
 
+# Some local models (e.g. Ollama llama3:8b) reject `tools=[...]` with HTTP 400.
+# Default off so production stays unchanged. Set LLM_TOOLS_DISABLED=1 when
+# iterating against a non-tool-capable backend — the freestyle handler will
+# skip the Edamam tool call. Eval scoring (intent + ingredient name) doesn't
+# depend on the tool, only on the model's text extraction.
+LLM_TOOLS_DISABLED: bool = os.environ.get("LLM_TOOLS_DISABLED", "").lower() in ("1", "true", "yes")
+
 ROUTER_CONFIDENCE_THRESHOLD: float = float(
     os.environ.get("LLM_ROUTER_CONFIDENCE_THRESHOLD", "0.7")
 )

--- a/backend/gemini_client/config.py
+++ b/backend/gemini_client/config.py
@@ -1,0 +1,25 @@
+"""Module-local config for the gemini_client.
+
+Owns LLM client config (base_url / api_key / model) and the per-handler
+confidence thresholds. Defaults preserve the production setup (Groq
++ llama-3.1-8b-instant); env-var overrides exist so the eval harness
+can target a local Ollama for fast iteration.
+
+Kept package-local on purpose. Importing from `backend/app/` here would
+break the rule that gemini_client is a self-contained pure function.
+"""
+
+from __future__ import annotations
+
+import os
+
+LLM_BASE_URL: str | None = os.environ.get("LLM_BASE_URL") or None
+LLM_API_KEY: str = os.environ.get("LLM_API_KEY") or os.environ.get("GROQ_API_KEY", "")
+LLM_MODEL: str = os.environ.get("LLM_MODEL", "llama-3.1-8b-instant")
+
+ROUTER_CONFIDENCE_THRESHOLD: float = float(
+    os.environ.get("LLM_ROUTER_CONFIDENCE_THRESHOLD", "0.7")
+)
+FREESTYLE_CONFIDENCE_THRESHOLD: float = float(
+    os.environ.get("LLM_FREESTYLE_CONFIDENCE_THRESHOLD", "0.75")
+)

--- a/backend/gemini_client/config.py
+++ b/backend/gemini_client/config.py
@@ -13,6 +13,14 @@ from __future__ import annotations
 
 import os
 
+from dotenv import find_dotenv, load_dotenv
+
+# Load .env BEFORE reading env vars, otherwise GROQ_API_KEY (and any other
+# .env-only secrets) would be missed when this module is imported before
+# client.py's own load_dotenv. The original _groq.py read os.environ at
+# call time and didn't have this race; centralising config means we have to.
+load_dotenv(find_dotenv())
+
 LLM_BASE_URL: str | None = os.environ.get("LLM_BASE_URL") or None
 LLM_API_KEY: str = os.environ.get("LLM_API_KEY") or os.environ.get("GROQ_API_KEY", "")
 LLM_MODEL: str = os.environ.get("LLM_MODEL", "llama-3.1-8b-instant")

--- a/backend/gemini_client/evals/README.md
+++ b/backend/gemini_client/evals/README.md
@@ -53,9 +53,14 @@ Run the suite against Ollama:
 LLM_BASE_URL=http://localhost:11434 \
 LLM_API_KEY=ollama \
 LLM_MODEL=llama3:8b \
+LLM_TOOLS_DISABLED=1 \
 EVAL_RATE_LIMIT_DELAY=0 \
 uv run pytest gemini_client/evals/ -q --tb=short
 ```
+
+`LLM_TOOLS_DISABLED=1` is required for tool-incapable local models (Ollama
+`llama3:8b` returns HTTP 400 on `tools=[...]`). Production with Groq +
+`llama-3.1-8b-instant` does support tools and runs without the flag.
 
 The Groq SDK accepts a `base_url`; `gemini_client/config.py` reads
 `LLM_BASE_URL` / `LLM_API_KEY` / `LLM_MODEL` and threads them through

--- a/backend/gemini_client/evals/README.md
+++ b/backend/gemini_client/evals/README.md
@@ -33,6 +33,41 @@ or in the repo-root `.env` (the client calls `dotenv.find_dotenv()`,
 which walks up the tree). Check with `echo $GROQ_API_KEY | head -c 8`
 or `grep GROQ ../.env`.
 
+## Iteration loop against a local Ollama
+
+The Groq run is the gate, but it's slow (~40 min wall) and rate-limited.
+For prompt iteration and threshold tuning, point the suite at a local
+Ollama instead — it's free, no rate limit, and a full 160-case run
+finishes in a few minutes.
+
+Setup once:
+
+```bash
+ollama pull llama3.1:8b
+ollama serve   # in another terminal; serves at http://localhost:11434
+```
+
+Run the suite against Ollama:
+
+```bash
+LLM_BASE_URL=http://localhost:11434/v1 \
+LLM_API_KEY=ollama \
+LLM_MODEL=llama3.1:8b \
+EVAL_RATE_LIMIT_DELAY=0 \
+uv run pytest gemini_client/evals/ -q --tb=short
+```
+
+The Groq SDK accepts a `base_url`; `gemini_client/config.py` reads
+`LLM_BASE_URL` / `LLM_API_KEY` / `LLM_MODEL` and threads them through
+`_groq.get_client()`. `EVAL_RATE_LIMIT_DELAY=0` disables the per-test
+sleep that otherwise protects the Groq free tier.
+
+**Caveat — Ollama is quantized.** Local `llama3.1:8b` is typically a
+`q4_K_M` weight while Groq runs full-precision inference, so per-case
+classifications can differ. Confidence values and threshold tuning
+done on Ollama are **directional**, not final. Re-validate against
+Groq before locking a baseline change.
+
 At the end, the scorecard prints to the terminal. Example:
 
 ```

--- a/backend/gemini_client/evals/README.md
+++ b/backend/gemini_client/evals/README.md
@@ -50,9 +50,9 @@ ollama serve   # in another terminal; serves at http://localhost:11434
 Run the suite against Ollama:
 
 ```bash
-LLM_BASE_URL=http://localhost:11434/v1 \
+LLM_BASE_URL=http://localhost:11434 \
 LLM_API_KEY=ollama \
-LLM_MODEL=llama3.1:8b \
+LLM_MODEL=llama3:8b \
 EVAL_RATE_LIMIT_DELAY=0 \
 uv run pytest gemini_client/evals/ -q --tb=short
 ```
@@ -61,6 +61,17 @@ The Groq SDK accepts a `base_url`; `gemini_client/config.py` reads
 `LLM_BASE_URL` / `LLM_API_KEY` / `LLM_MODEL` and threads them through
 `_groq.get_client()`. `EVAL_RATE_LIMIT_DELAY=0` disables the per-test
 sleep that otherwise protects the Groq free tier.
+
+**`LLM_BASE_URL` must not end in `/v1`** — the Groq SDK appends
+`/openai/v1/chat/completions` itself; an httpx transport in
+`_groq.py` rewrites that to `/v1/chat/completions` when the base URL
+isn't Groq, so Ollama's OpenAI-compatible endpoint at
+`http://localhost:11434/v1/chat/completions` is hit correctly.
+
+If you have a newer Ollama (`>= 0.5`-ish) you can pull `llama3.1:8b`;
+older versions (e.g. `0.22.x`) reject the manifest, so use `llama3:8b`
+as a directional substitute. Either way, threshold values tuned on
+Ollama are not final — re-validate against Groq.
 
 **Caveat — Ollama is quantized.** Local `llama3.1:8b` is typically a
 `q4_K_M` weight while Groq runs full-precision inference, so per-case

--- a/backend/gemini_client/evals/conftest.py
+++ b/backend/gemini_client/evals/conftest.py
@@ -193,6 +193,7 @@ def pytest_sessionfinish(session, exitstatus):
     if _ROUTER_RESULTS:
         _report_router_scorecard(reporter, baseline, tol, session)
         if not sc.results:
+            _write_eval_results_json(sc, baseline)
             return
 
     reporter.write_sep("=", "Gemini eval scorecard")

--- a/backend/gemini_client/evals/conftest.py
+++ b/backend/gemini_client/evals/conftest.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import date
@@ -25,6 +26,8 @@ from gemini_client.router import Mode
 EVALS_DIR = Path(__file__).parent
 UTTERANCES_PATH = EVALS_DIR / "utterances.yaml"
 BASELINE_PATH = EVALS_DIR / "baseline_scores.json"
+
+_RATE_LIMIT_DELAY = float(os.environ.get("EVAL_RATE_LIMIT_DELAY", "1.5"))
 
 
 # Default Mode per eval category. The router test uses this as the expected
@@ -57,10 +60,15 @@ def expected_mode_for(case: dict) -> Mode | None:
 
 @pytest.fixture(autouse=True)
 async def rate_limit_buffer():
-    """Sleep 1.5s after each test. Groq free tier throttles aggressively;
-    this mirrors the sleep in backend/gemini_client/tests/test_utterances.py."""
+    """Sleep between tests to respect provider rate limits.
+
+    Default 1.5s mirrors the Groq free-tier sleep used elsewhere in tests.
+    Override via EVAL_RATE_LIMIT_DELAY (e.g. set to 0 when iterating against
+    a local Ollama).
+    """
     yield
-    await asyncio.sleep(1.5)
+    if _RATE_LIMIT_DELAY > 0:
+        await asyncio.sleep(_RATE_LIMIT_DELAY)
 
 
 @dataclass

--- a/backend/gemini_client/evals/conftest.py
+++ b/backend/gemini_client/evals/conftest.py
@@ -78,13 +78,22 @@ class CaseResult:
     category: str
     passed: bool
     diff: str
+    confidence: float | None = None
+    confidence_source: str | None = None
 
 
 class Scorecard:
     def __init__(self) -> None:
         self.results: list[CaseResult] = []
 
-    def record(self, case: dict, passed: bool, diff: str) -> None:
+    def record(
+        self,
+        case: dict,
+        passed: bool,
+        diff: str,
+        confidence: float | None = None,
+        confidence_source: str | None = None,
+    ) -> None:
         self.results.append(
             CaseResult(
                 case_id=case["id"],
@@ -92,6 +101,8 @@ class Scorecard:
                 category=case.get("category", case["expected_intent"]),
                 passed=passed,
                 diff=diff,
+                confidence=confidence,
+                confidence_source=confidence_source,
             )
         )
 
@@ -121,14 +132,33 @@ _SCORECARD = Scorecard()
 # Router eval results — keyed on expected mode, list of pass bools per case.
 _ROUTER_RESULTS: dict[str, list[bool]] = defaultdict(list)
 
+# Full per-case records for the router eval. Mirrors _SCORECARD.results in
+# spirit but for the router-only suite, which doesn't pass through Scorecard.
+_ROUTER_CASES: list[dict] = []
+
 
 @pytest.fixture(scope="session")
 def scorecard() -> Scorecard:
     return _SCORECARD
 
 
-def record_router_result(expected_mode: str, passed: bool) -> None:
+def record_router_result(
+    case_id: str,
+    expected_mode: str,
+    actual_mode: str,
+    passed: bool,
+    confidence: float | None = None,
+    confidence_source: str | None = None,
+) -> None:
     _ROUTER_RESULTS[expected_mode].append(passed)
+    _ROUTER_CASES.append({
+        "id": case_id,
+        "expected_mode": expected_mode,
+        "actual_mode": actual_mode,
+        "passed": passed,
+        "confidence": confidence,
+        "confidence_source": confidence_source,
+    })
 
 
 def _load_baseline() -> dict:
@@ -192,7 +222,11 @@ def pytest_sessionfinish(session, exitstatus):
         reporter.write_line("")
         reporter.write_line(f"Failures ({len(fails)}):")
         for r in fails:
-            reporter.write_line(f"  [{r.case_id}] {r.diff}")
+            conf_str = f" conf={r.confidence:.2f}" if r.confidence is not None else ""
+            reporter.write_line(f"  [{r.case_id}]{conf_str} {r.diff}")
+
+    _report_calibration(reporter, sc)
+    _write_eval_results_json(sc, baseline)
 
     # Regression gate
     #
@@ -226,6 +260,87 @@ def pytest_sessionfinish(session, exitstatus):
             f"{proposed_path.name}. Review, adjust the 'notes' field, "
             f"then rename to baseline_scores.json and commit."
         )
+
+
+def _report_calibration(reporter, sc: Scorecard) -> None:
+    """Per-confidence-bucket pass/fail breakdown.
+
+    The point: when the model gets a case wrong, did it know it was unsure?
+    A misclassification with confidence < threshold is a "would-be-saved by
+    disambiguation" case. A misclassification with confidence >= 0.85 is a
+    "confidently wrong" case — the deeper problem the threshold can't fix.
+    """
+    rated = [r for r in sc.results if r.confidence is not None]
+    if not rated:
+        return
+
+    reporter.write_line("")
+    reporter.write_sep("=", "Calibration report")
+
+    passes = [r for r in rated if r.passed]
+    fails = [r for r in rated if not r.passed]
+
+    def _stats(rs: list) -> str:
+        if not rs:
+            return "(none)"
+        vs = sorted(r.confidence for r in rs)
+        mean = sum(vs) / len(vs)
+        median = vs[len(vs) // 2]
+        return f"n={len(vs)} mean={mean:.3f} median={median:.3f} min={vs[0]:.2f} max={vs[-1]:.2f}"
+
+    reporter.write_line(f"  Passes:   {_stats(passes)}")
+    reporter.write_line(f"  Failures: {_stats(fails)}")
+
+    buckets = [(0.0, 0.5), (0.5, 0.7), (0.7, 0.85), (0.85, 1.01)]
+    reporter.write_line("")
+    reporter.write_line("  Failures by confidence:")
+    for lo, hi in buckets:
+        in_bucket = [r for r in fails if lo <= r.confidence < hi]
+        if not in_bucket:
+            continue
+        label = f"  [{lo:.2f}, {hi:.2f})"
+        reporter.write_line(f"  {label:<18} {len(in_bucket):>3} cases")
+        for r in in_bucket:
+            reporter.write_line(
+                f"      [{r.case_id}] conf={r.confidence:.2f} "
+                f"src={r.confidence_source} {r.diff}"
+            )
+
+    confidently_wrong = [r for r in fails if r.confidence >= 0.85]
+    saveable = [r for r in fails if r.confidence < 0.85]
+    reporter.write_line("")
+    reporter.write_line(
+        f"  Saveable-by-disambig (conf<0.85): {len(saveable)}    "
+        f"Confidently-wrong (conf>=0.85): {len(confidently_wrong)}"
+    )
+
+
+def _write_eval_results_json(sc: Scorecard, baseline: dict) -> None:
+    """Write a per-case sidecar so suggest_thresholds.py and any future
+    analysis can read structured results without re-running the suite."""
+    if not sc.results and not _ROUTER_CASES:
+        return
+    payload = {
+        "measured_on": date.today().isoformat(),
+        "model_snapshot": baseline.get("model_snapshot", "unknown") if baseline else "unknown",
+        "eval": [
+            {
+                "id": r.case_id,
+                "intent": r.intent,
+                "category": r.category,
+                "passed": r.passed,
+                "diff": r.diff,
+                "confidence": r.confidence,
+                "confidence_source": r.confidence_source,
+            }
+            for r in sc.results
+        ],
+        "router": list(_ROUTER_CASES),
+    }
+    out = EVALS_DIR / "eval_results.json"
+    with out.open("w") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
 
 
 def _report_router_scorecard(reporter, baseline: dict, tol: float, session) -> None:

--- a/backend/gemini_client/evals/suggest_thresholds.py
+++ b/backend/gemini_client/evals/suggest_thresholds.py
@@ -1,0 +1,185 @@
+"""Suggest confidence thresholds from a recorded eval run.
+
+Reads eval_results.json (written by conftest.pytest_sessionfinish) and
+sweeps candidate thresholds per source (router_llm, freestyle_llm,
+qa_llm, small_talk_llm). For each threshold T, it reports:
+
+- precision (when confidence >= T, what % were correct)
+- recall (what % of correct cases were above T — if we threshold out
+  cases below T, this is the fraction of correct cases we still answer)
+- mistakes-caught (what % of failures were below T — would-be-routed to
+  disambiguation)
+- unnecessary-asks (what % of correct cases were below T — user friction)
+
+Recommends two thresholds per source: F1-maximizing, and the highest
+threshold that keeps recall ≥ 0.95 (precision-favoring while not
+nuking recall).
+
+Usage:
+    uv run python -m gemini_client.evals.suggest_thresholds
+    uv run python -m gemini_client.evals.suggest_thresholds --input path/to/eval_results.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+DEFAULT_INPUT = Path(__file__).parent / "eval_results.json"
+
+# Sweep thresholds 0.50 to 1.00 step 0.05.
+_CANDIDATES: list[float] = [round(0.5 + 0.05 * i, 2) for i in range(11)]
+
+
+def _bucket_metrics(rows: list[dict], threshold: float) -> dict:
+    """All counts are inclusive of the threshold on the answered side
+    (confidence >= T → answered)."""
+    rated = [r for r in rows if r.get("confidence") is not None]
+    if not rated:
+        return {}
+
+    answered = [r for r in rated if r["confidence"] >= threshold]
+    asked = [r for r in rated if r["confidence"] < threshold]
+    correct = [r for r in rated if r["passed"]]
+    wrong = [r for r in rated if not r["passed"]]
+
+    answered_correct = sum(1 for r in answered if r["passed"])
+    answered_wrong = sum(1 for r in answered if not r["passed"])
+    asked_correct = sum(1 for r in asked if r["passed"])
+    asked_wrong = sum(1 for r in asked if not r["passed"])
+
+    precision = answered_correct / len(answered) if answered else 1.0
+    recall = answered_correct / len(correct) if correct else 1.0
+    mistakes_caught = asked_wrong / len(wrong) if wrong else 0.0
+    unnecessary_asks = asked_correct / len(correct) if correct else 0.0
+    f1 = (
+        (2 * precision * recall) / (precision + recall)
+        if (precision + recall)
+        else 0.0
+    )
+
+    return {
+        "threshold": threshold,
+        "n_rated": len(rated),
+        "answered": len(answered),
+        "asked": len(asked),
+        "answered_correct": answered_correct,
+        "answered_wrong": answered_wrong,
+        "asked_correct": asked_correct,
+        "asked_wrong": asked_wrong,
+        "precision": precision,
+        "recall": recall,
+        "mistakes_caught": mistakes_caught,
+        "unnecessary_asks": unnecessary_asks,
+        "f1": f1,
+    }
+
+
+def _best_thresholds(rows: list[dict]) -> tuple[dict | None, dict | None]:
+    """Returns (f1_max, recall_floor): row dicts for the F1-maximizing
+    threshold and the highest threshold that keeps recall >= 0.95."""
+    metrics = [m for m in (_bucket_metrics(rows, t) for t in _CANDIDATES) if m]
+    if not metrics:
+        return None, None
+    f1_max = max(metrics, key=lambda m: (m["f1"], m["threshold"]))
+    above_recall = [m for m in metrics if m["recall"] >= 0.95]
+    recall_floor = max(above_recall, key=lambda m: m["threshold"]) if above_recall else None
+    return f1_max, recall_floor
+
+
+def _format_threshold_row(m: dict) -> str:
+    return (
+        f"  T={m['threshold']:.2f}  "
+        f"P={m['precision']:.3f}  "
+        f"R={m['recall']:.3f}  "
+        f"F1={m['f1']:.3f}  "
+        f"caught={m['mistakes_caught']:.2f}  "
+        f"unnecessary={m['unnecessary_asks']:.2f}  "
+        f"(answered {m['answered']}/{m['n_rated']}, "
+        f"of which {m['answered_wrong']} wrong)"
+    )
+
+
+def _report_for_source(name: str, rows: list[dict]) -> None:
+    rated = [r for r in rows if r.get("confidence") is not None]
+    if not rated:
+        print(f"\n[{name}] no rated cases — skipping")
+        return
+
+    correct = sum(1 for r in rated if r["passed"])
+    wrong = len(rated) - correct
+    print(f"\n[{name}] {len(rated)} rated cases ({correct} correct, {wrong} wrong)")
+
+    if wrong == 0:
+        print(f"  No wrong cases — threshold tuning is moot for {name}.")
+
+    print("  Sweep:")
+    for t in _CANDIDATES:
+        m = _bucket_metrics(rated, t)
+        if m:
+            print(_format_threshold_row(m))
+
+    f1_max, recall_floor = _best_thresholds(rated)
+    print("\n  Recommendations:")
+    if f1_max:
+        print(
+            f"    F1-max:        T={f1_max['threshold']:.2f}  "
+            f"F1={f1_max['f1']:.3f}  P={f1_max['precision']:.3f}  R={f1_max['recall']:.3f}"
+        )
+    if recall_floor:
+        print(
+            f"    Recall ≥ 0.95: T={recall_floor['threshold']:.2f}  "
+            f"P={recall_floor['precision']:.3f}  R={recall_floor['recall']:.3f}"
+        )
+    else:
+        print("    Recall ≥ 0.95: no candidate threshold preserves recall")
+
+
+def _group_by_source(rows: list[dict]) -> dict[str, list[dict]]:
+    groups: dict[str, list[dict]] = defaultdict(list)
+    for r in rows:
+        src = r.get("confidence_source") or "unknown"
+        groups[src].append(r)
+    return groups
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--input",
+        type=Path,
+        default=DEFAULT_INPUT,
+        help=f"Path to eval_results.json (default: {DEFAULT_INPUT.name})",
+    )
+    args = p.parse_args(argv)
+
+    if not args.input.exists():
+        print(f"error: {args.input} not found — run the eval suite first", file=sys.stderr)
+        return 1
+
+    with args.input.open() as f:
+        payload = json.load(f)
+
+    print(f"Eval results: {args.input}")
+    print(f"  measured_on:    {payload.get('measured_on', 'unknown')}")
+    print(f"  model_snapshot: {payload.get('model_snapshot', 'unknown')}")
+
+    eval_rows = payload.get("eval", [])
+    router_rows = payload.get("router", [])
+
+    print(f"\n# End-to-end eval ({len(eval_rows)} cases)")
+    for src, rows in sorted(_group_by_source(eval_rows).items()):
+        _report_for_source(src, rows)
+
+    print(f"\n# Router-only eval ({len(router_rows)} cases)")
+    for src, rows in sorted(_group_by_source(router_rows).items()):
+        _report_for_source(f"router/{src}", rows)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/gemini_client/evals/test_eval.py
+++ b/backend/gemini_client/evals/test_eval.py
@@ -118,5 +118,11 @@ async def test_case(case, scorecard):
         pytest.fail(f"[{case['id']}] {diff}")
 
     passed, diff = _compare(case, result)
-    scorecard.record(case, passed, diff)
+    scorecard.record(
+        case,
+        passed,
+        diff,
+        confidence=result.confidence,
+        confidence_source=result.source,
+    )
     assert passed, f"[{case['id']}] {diff}"

--- a/backend/gemini_client/evals/test_router.py
+++ b/backend/gemini_client/evals/test_router.py
@@ -36,13 +36,16 @@ CASES = _load_router_cases()
 )
 async def test_router(case):
     expected = expected_mode_for(case)
-    actual = await classify(
+    classification = await classify(
         transcript=case["utterance_text"],
         session_ingredients=[],
         pending_clarification=case.get("pending_clarification"),
     )
-    passed = actual == expected
+    passed = classification.mode == expected
     record_router_result(expected.value, passed)
     assert passed, (
-        f"[{case['id']}] expected_mode={expected.value} got={actual.value}"
+        f"[{case['id']}] expected_mode={expected.value} "
+        f"got={classification.mode.value} "
+        f"confidence={classification.confidence} "
+        f"source={classification.source}"
     )

--- a/backend/gemini_client/evals/test_router.py
+++ b/backend/gemini_client/evals/test_router.py
@@ -42,7 +42,14 @@ async def test_router(case):
         pending_clarification=case.get("pending_clarification"),
     )
     passed = classification.mode == expected
-    record_router_result(expected.value, passed)
+    record_router_result(
+        case_id=case["id"],
+        expected_mode=expected.value,
+        actual_mode=classification.mode.value,
+        passed=passed,
+        confidence=classification.confidence,
+        confidence_source=classification.source,
+    )
     assert passed, (
         f"[{case['id']}] expected_mode={expected.value} "
         f"got={classification.mode.value} "

--- a/backend/gemini_client/handlers/freestyle.py
+++ b/backend/gemini_client/handlers/freestyle.py
@@ -28,10 +28,13 @@ async def handle(input: HandlerInput) -> dict:
     # Stamp the disambiguation kind so the route layer's encoder knows which
     # sentinel to write. The prompt only emits {best, second}; the handler
     # owns the kind label since it's a backend-internal concept.
+    # Malformed dicts (missing best/second) are dropped — surfacing them
+    # would 502 via the Pydantic validator and confuse the route layer's
+    # soft-fall, hiding the prompt regression.
     disambig = parsed.get("disambiguation")
     if isinstance(disambig, dict) and "best" in disambig and "second" in disambig:
         disambig["kind"] = "extraction"
-    elif disambig is None or disambig == {}:
+    else:
         parsed.pop("disambiguation", None)
 
     return parsed

--- a/backend/gemini_client/handlers/freestyle.py
+++ b/backend/gemini_client/handlers/freestyle.py
@@ -24,4 +24,14 @@ async def handle(input: HandlerInput) -> dict:
     raw = await chat_with_tools(messages, tools=[NUTRITION_TOOL])
     parsed = extract_json(raw)
     parsed["source"] = "freestyle_llm"
+
+    # Stamp the disambiguation kind so the route layer's encoder knows which
+    # sentinel to write. The prompt only emits {best, second}; the handler
+    # owns the kind label since it's a backend-internal concept.
+    disambig = parsed.get("disambiguation")
+    if isinstance(disambig, dict) and "best" in disambig and "second" in disambig:
+        disambig["kind"] = "extraction"
+    elif disambig is None or disambig == {}:
+        parsed.pop("disambiguation", None)
+
     return parsed

--- a/backend/gemini_client/handlers/freestyle.py
+++ b/backend/gemini_client/handlers/freestyle.py
@@ -22,4 +22,6 @@ async def handle(input: HandlerInput) -> dict:
         {"role": "user", "content": user_msg},
     ]
     raw = await chat_with_tools(messages, tools=[NUTRITION_TOOL])
-    return extract_json(raw)
+    parsed = extract_json(raw)
+    parsed["source"] = "freestyle_llm"
+    return parsed

--- a/backend/gemini_client/handlers/freestyle.py
+++ b/backend/gemini_client/handlers/freestyle.py
@@ -6,6 +6,7 @@ clarification-reply parsing) and the user-said-they're-done signal.
 
 from pathlib import Path
 
+from .. import config
 from .._groq import chat_with_tools, extract_json
 from ..nutrition_tool import NUTRITION_TOOL
 from .base import HandlerInput
@@ -21,7 +22,8 @@ async def handle(input: HandlerInput) -> dict:
         {"role": "system", "content": _PROMPT},
         {"role": "user", "content": user_msg},
     ]
-    raw = await chat_with_tools(messages, tools=[NUTRITION_TOOL])
+    tools = None if config.LLM_TOOLS_DISABLED else [NUTRITION_TOOL]
+    raw = await chat_with_tools(messages, tools=tools)
     parsed = extract_json(raw)
     parsed["source"] = "freestyle_llm"
 

--- a/backend/gemini_client/handlers/qa.py
+++ b/backend/gemini_client/handlers/qa.py
@@ -20,4 +20,6 @@ async def handle(input: HandlerInput) -> dict:
         {"role": "user", "content": user_msg},
     ]
     raw = await chat_with_tools(messages)
-    return extract_json(raw)
+    parsed = extract_json(raw)
+    parsed["source"] = "qa_llm"
+    return parsed

--- a/backend/gemini_client/handlers/small_talk.py
+++ b/backend/gemini_client/handlers/small_talk.py
@@ -20,4 +20,6 @@ async def handle(input: HandlerInput) -> dict:
         {"role": "user", "content": user_msg},
     ]
     raw = await chat_with_tools(messages)
-    return extract_json(raw)
+    parsed = extract_json(raw)
+    parsed["source"] = "small_talk_llm"
+    return parsed

--- a/backend/gemini_client/prompts/freestyle.txt
+++ b/backend/gemini_client/prompts/freestyle.txt
@@ -4,7 +4,8 @@ Schema:
 {
   "intent": "add_ingredient" | "finish_recipe",
   "ack": <string, ≤12 words>,
-  "items": <list of ingredient objects, or null>
+  "items": <list of ingredient objects, or null>,
+  "confidence": <float 0.0-1.0, your confidence the intent + items are right>
 }
 
 Each item:
@@ -48,5 +49,12 @@ Each item:
 
 ## Clarification replies
 When context says 'You previously asked the user: "How much X..."' the next utterance is the qty answer. Return intent=add_ingredient with items containing the ingredient, parsed qty, and parsed unit. If the user is uncertain ("I don't know", "not sure", "maybe", no number), use a culinary default (garlic→2 cloves, olive oil→2 tbsp, salt→0.5 tsp, onion→1 medium, pasta→100 grams). Do NOT return qty=null. Ack reflects the estimate: "I'll use 2 cloves, a typical amount."
+
+## Confidence
+Self-report a `confidence` float from 0.0 to 1.0 reflecting how sure you are about both the intent classification AND the extracted items.
+- 0.95+ — utterance names a specific ingredient with clear qty/unit, or is an unambiguous finish signal.
+- 0.75–0.95 — clearly an add_ingredient/finish_recipe but qty is vague or the ingredient name is slightly fuzzy.
+- 0.5–0.75 — could plausibly be add_ingredient or something else (a question, small talk); or you can't tell which of two plausible ingredients the user meant.
+- below 0.5 — genuinely ambiguous.
 
 Output ONLY the JSON object. Zero extra characters outside it.

--- a/backend/gemini_client/prompts/freestyle.txt
+++ b/backend/gemini_client/prompts/freestyle.txt
@@ -5,7 +5,8 @@ Schema:
   "intent": "add_ingredient" | "finish_recipe",
   "ack": <string, ≤12 words>,
   "items": <list of ingredient objects, or null>,
-  "confidence": <float 0.0-1.0, your confidence the intent + items are right>
+  "confidence": <float 0.0-1.0, your confidence the intent + items are right>,
+  "disambiguation": {"best": <string>, "second": <string>} | null
 }
 
 Each item:
@@ -50,11 +51,22 @@ Each item:
 ## Clarification replies
 When context says 'You previously asked the user: "How much X..."' the next utterance is the qty answer. Return intent=add_ingredient with items containing the ingredient, parsed qty, and parsed unit. If the user is uncertain ("I don't know", "not sure", "maybe", no number), use a culinary default (garlic→2 cloves, olive oil→2 tbsp, salt→0.5 tsp, onion→1 medium, pasta→100 grams). Do NOT return qty=null. Ack reflects the estimate: "I'll use 2 cloves, a typical amount."
 
+## Disambiguation replies
+When context says 'You previously asked the user: "Did you mean X or Y?" — their reply follows.', the next utterance is the user's choice between two ingredient candidates. Treat the chosen option as the user's actual ingredient and run normal extraction (intent=add_ingredient, items=[{name: chosen, ...}], qty=null if not stated). DO NOT echo a second disambiguation question.
+
 ## Confidence
 Self-report a `confidence` float from 0.0 to 1.0 reflecting how sure you are about both the intent classification AND the extracted items.
 - 0.95+ — utterance names a specific ingredient with clear qty/unit, or is an unambiguous finish signal.
 - 0.75–0.95 — clearly an add_ingredient/finish_recipe but qty is vague or the ingredient name is slightly fuzzy.
 - 0.5–0.75 — could plausibly be add_ingredient or something else (a question, small talk); or you can't tell which of two plausible ingredients the user meant.
 - below 0.5 — genuinely ambiguous.
+
+## Disambiguation (extraction-level)
+If your confidence is below 0.75 AND there are exactly two plausible ingredient interpretations of the same user phrase (examples: "cream" → heavy cream OR sour cream; "rice" → rice flour OR rice noodles; "vinegar" → white vinegar OR balsamic), emit:
+- `disambiguation`: {"best": "<top guess>", "second": "<runner-up>"}
+- `ack`: "Did you mean <best> or <second>?" (≤12 words)
+- `items`: [] (empty list — do NOT pick one and proceed)
+
+Only emit `disambiguation` for a genuine name-fork, not for missing-quantity (those go through the existing qty clarification flow with qty=null). When `disambiguation` is null, omit it or set it to null.
 
 Output ONLY the JSON object. Zero extra characters outside it.

--- a/backend/gemini_client/prompts/freestyle.txt
+++ b/backend/gemini_client/prompts/freestyle.txt
@@ -5,8 +5,7 @@ Schema:
   "intent": "add_ingredient" | "finish_recipe",
   "ack": <string, ≤12 words>,
   "items": <list of ingredient objects, or null>,
-  "confidence": <float 0.0-1.0, your confidence the intent + items are right>,
-  "disambiguation": {"best": <string>, "second": <string>} | null
+  "confidence": <float 0.0-1.0, your confidence the intent + items are right>
 }
 
 Each item:
@@ -60,13 +59,5 @@ Self-report a `confidence` float from 0.0 to 1.0 reflecting how sure you are abo
 - 0.75–0.95 — clearly an add_ingredient/finish_recipe but qty is vague or the ingredient name is slightly fuzzy.
 - 0.5–0.75 — could plausibly be add_ingredient or something else (a question, small talk); or you can't tell which of two plausible ingredients the user meant.
 - below 0.5 — genuinely ambiguous.
-
-## Disambiguation (extraction-level)
-If your confidence is below 0.75 AND there are exactly two plausible ingredient interpretations of the same user phrase (examples: "cream" → heavy cream OR sour cream; "rice" → rice flour OR rice noodles; "vinegar" → white vinegar OR balsamic), emit:
-- `disambiguation`: {"best": "<top guess>", "second": "<runner-up>"}
-- `ack`: "Did you mean <best> or <second>?" (≤12 words)
-- `items`: [] (empty list — do NOT pick one and proceed)
-
-Only emit `disambiguation` for a genuine name-fork, not for missing-quantity (those go through the existing qty clarification flow with qty=null). When `disambiguation` is null, omit it or set it to null.
 
 Output ONLY the JSON object. Zero extra characters outside it.

--- a/backend/gemini_client/prompts/qa.txt
+++ b/backend/gemini_client/prompts/qa.txt
@@ -4,7 +4,8 @@ Schema:
 {
   "intent": "question",
   "ack": <string, ≤12 words spoken aloud>,
-  "answer": <string, 1-2 sentences of practical cooking advice>
+  "answer": <string, 1-2 sentences of practical cooking advice>,
+  "confidence": <float 0.0-1.0, your confidence in the answer>
 }
 
 ## ack
@@ -17,5 +18,10 @@ Schema:
 - For substitution questions: name 1-2 substitutes with rough ratio if relevant.
 - For technique questions: 1-2 sentence how-to.
 - For timing/doneness: a specific time range or visual cue.
+
+## confidence
+- 0.95+ — you're confident the answer is correct and useful.
+- 0.7–0.95 — answer is a reasonable best guess but you're not certain.
+- below 0.7 — the question is unclear or you genuinely don't know.
 
 Output ONLY the JSON object.

--- a/backend/gemini_client/prompts/router.txt
+++ b/backend/gemini_client/prompts/router.txt
@@ -1,4 +1,4 @@
-You classify a hands-free voice utterance from a user who is cooking. Pick exactly one mode and return ONLY a JSON object: {"mode": "<mode>"}.
+You classify a hands-free voice utterance from a user who is cooking. Pick exactly one mode and return ONLY a JSON object with the schema shown at the end.
 
 Modes:
 - freestyle: user is adding, changing, removing, or narrating an ingredient action; OR signalling they are done cooking. Examples: "add 2 cloves of garlic", "use 3 tbsp olive oil instead", "added oil to the pan", "threw in some salt", "I'm done", "that's everything".
@@ -12,4 +12,17 @@ Past-tense narration of an ingredient action ("added oil", "threw in some garlic
 
 A short reply that gives a quantity ("two cloves", "about a cup", "I don't know") is freestyle — the user is answering a clarification.
 
-Output ONLY: {"mode": "freestyle" | "qa" | "small_talk" | "recipe"}.
+## Confidence
+
+Self-report a `confidence` float from 0.0 to 1.0 reflecting how sure you are.
+- 0.95+ — utterance is unambiguous; only one mode plausibly fits.
+- 0.7–0.95 — clearly leans one way; an alternative is conceivable but unlikely.
+- 0.5–0.7 — the utterance could plausibly be one of two modes; pick your best guess as `mode` and the runner-up as `second_choice`.
+- below 0.5 — genuinely confused. Still pick a `mode` and a `second_choice`.
+
+`second_choice` should be a different mode from `mode`, or null if you have no plausible alternative.
+
+## Output
+
+Output ONLY this JSON object, zero extra characters:
+{"mode": "freestyle" | "qa" | "small_talk" | "recipe", "confidence": <float 0.0-1.0>, "second_choice": "freestyle" | "qa" | "small_talk" | "recipe" | null}

--- a/backend/gemini_client/prompts/small_talk.txt
+++ b/backend/gemini_client/prompts/small_talk.txt
@@ -3,7 +3,8 @@ You are a voice-controlled cooking assistant. The user said something conversati
 Schema:
 {
   "intent": "acknowledgment" | "small_talk",
-  "ack": <string, ≤12 words>
+  "ack": <string, ≤12 words>,
+  "confidence": <float 0.0-1.0, your confidence the intent is right>
 }
 
 ## Intent
@@ -14,5 +15,10 @@ Schema:
 - ≤12 words. Short and friendly.
 - For acknowledgment: "You're welcome!", "Glad to help.", "Of course.", "Sounds good!"
 - For small_talk: "Glad you're enjoying it!", "Cooking is the best.", "Thanks!"
+
+## confidence
+- 0.9+ — clearly an ack or chitchat, no ingredient/question content.
+- 0.6–0.9 — leans conversational but contains a phrase that could be misread (e.g. "thanks chef" vs "thanks for the chef option").
+- below 0.6 — genuinely unclear.
 
 Output ONLY the JSON object.

--- a/backend/gemini_client/router.py
+++ b/backend/gemini_client/router.py
@@ -4,11 +4,21 @@ classify() decides which handler will run. Heuristic fast-paths short-circuit
 the cheap common cases (clarification reply, single-word ack, explicit
 finish, recipe-mode session); everything else goes to a small Groq call
 with a tight 4-way classification prompt.
+
+The return type is `Classification` — it carries the chosen mode plus
+self-reported confidence and the second-best mode when the LLM was used.
+Heuristic short-circuits return confidence=None and source="heuristic".
+The orchestrator uses this to decide whether to ask a disambiguation
+question instead of dispatching the handler.
 """
 
+from __future__ import annotations
+
 import logging
+from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
+from typing import Literal
 
 from . import _groq
 from .schemas import ParsedIngredient
@@ -21,6 +31,14 @@ class Mode(StrEnum):
     qa = "qa"
     small_talk = "small_talk"
     recipe = "recipe"
+
+
+@dataclass(frozen=True)
+class Classification:
+    mode: Mode
+    confidence: float | None
+    second_choice: Mode | None
+    source: Literal["heuristic", "llm"]
 
 
 _PROMPT_PATH = Path(__file__).parent / "prompts" / "router.txt"
@@ -49,39 +67,74 @@ def _normalize(text: str) -> str:
     return text.strip().lower().rstrip(".!?,")
 
 
+def _heuristic(mode: Mode) -> Classification:
+    return Classification(mode=mode, confidence=None, second_choice=None, source="heuristic")
+
+
 async def classify(
     transcript: str,
     session_ingredients: list[ParsedIngredient],
     pending_clarification: str | None,
     recipe_id: str | None = None,
-) -> Mode:
+) -> Classification:
     if pending_clarification is not None:
-        return Mode.freestyle
+        return _heuristic(Mode.freestyle)
 
     if recipe_id is not None:
-        return Mode.recipe
+        return _heuristic(Mode.recipe)
 
     normalized = _normalize(transcript)
 
     if normalized in _FINISH_PHRASES:
-        return Mode.freestyle
+        return _heuristic(Mode.freestyle)
 
     if normalized in _SHORT_ACKS:
-        return Mode.small_talk
+        return _heuristic(Mode.small_talk)
 
     return await _llm_classify(transcript)
 
 
-async def _llm_classify(transcript: str) -> Mode:
+def _parse_mode(value: object) -> Mode | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return Mode(value)
+    except ValueError:
+        return None
+
+
+def _parse_confidence(value: object) -> float | None:
+    try:
+        f = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    if not 0.0 <= f <= 1.0:
+        return None
+    return f
+
+
+async def _llm_classify(transcript: str) -> Classification:
     messages: list[dict] = [
         {"role": "system", "content": _ROUTER_PROMPT},
         {"role": "user", "content": f'User said: "{transcript}"'},
     ]
     raw = await _groq.chat_with_tools(messages)
     parsed = _groq.extract_json(raw)
-    mode_str = parsed.get("mode", "")
-    try:
-        return Mode(mode_str)
-    except ValueError:
-        log.warning("router returned unknown mode=%r; defaulting to freestyle", mode_str)
-        return Mode.freestyle
+
+    mode = _parse_mode(parsed.get("mode"))
+    if mode is None:
+        log.warning("router returned unknown mode=%r; defaulting to freestyle", parsed.get("mode"))
+        mode = Mode.freestyle
+
+    second_choice = _parse_mode(parsed.get("second_choice"))
+    if second_choice == mode:
+        second_choice = None
+
+    confidence = _parse_confidence(parsed.get("confidence"))
+
+    return Classification(
+        mode=mode,
+        confidence=confidence,
+        second_choice=second_choice,
+        source="llm",
+    )

--- a/backend/gemini_client/router.py
+++ b/backend/gemini_client/router.py
@@ -126,7 +126,10 @@ async def _llm_classify(transcript: str) -> Classification:
         log.warning("router returned unknown mode=%r; defaulting to freestyle", parsed.get("mode"))
         mode = Mode.freestyle
 
-    second_choice = _parse_mode(parsed.get("second_choice"))
+    raw_second = parsed.get("second_choice")
+    second_choice = _parse_mode(raw_second)
+    if raw_second is not None and second_choice is None:
+        log.debug("router second_choice unparseable=%r — disambig will be skipped", raw_second)
     if second_choice == mode:
         second_choice = None
 

--- a/backend/gemini_client/schemas.py
+++ b/backend/gemini_client/schemas.py
@@ -20,6 +20,22 @@ class ParsedIngredient(BaseModel):
     action: Literal["add", "replace"] = "add"
 
 
+class Disambiguation(BaseModel):
+    """Internal disambiguation marker returned when confidence is low.
+
+    `kind` distinguishes a router-layer disambiguation ("did you mean to
+    add an ingredient or ask a question?") from an extraction-layer one
+    ("did you mean rice flour or rice noodles?"). `best` and `second` are
+    opaque strings — Mode values for kind="router", ingredient names for
+    kind="extraction". Consumed by backend/app/routes/utterance.py to
+    encode the right pending_clarification sentinel.
+    """
+
+    kind: Literal["router", "extraction"]
+    best: str
+    second: str
+
+
 class UtteranceResponse(BaseModel):
     intent: Intent
     ack: str = Field(..., description="Spoken acknowledgement, <=12 words.")
@@ -30,7 +46,11 @@ class UtteranceResponse(BaseModel):
     # `confidence` is the dominant model's self-reported 0.0-1.0 score for
     # this utterance; `source` identifies which subsystem produced it
     # (e.g. "freestyle_llm", "qa_llm", "small_talk_llm", "router_llm").
-    # The route layer uses these for low-confidence routing and structured
-    # logging; backend/app/schemas/utterance.py does NOT carry them.
+    # `disambiguation` carries the top-2 candidates when confidence was
+    # below threshold so the route layer can persist a structured pending
+    # clarification. The route layer uses these for low-confidence routing
+    # and structured logging; backend/app/schemas/utterance.py does NOT
+    # carry them.
     confidence: float | None = None
     source: str | None = None
+    disambiguation: Disambiguation | None = None

--- a/backend/gemini_client/schemas.py
+++ b/backend/gemini_client/schemas.py
@@ -25,3 +25,12 @@ class UtteranceResponse(BaseModel):
     ack: str = Field(..., description="Spoken acknowledgement, <=12 words.")
     items: list[ParsedIngredient] | None = None
     answer: str | None = None
+
+    # Internal-only fields (not propagated to mobile by the route layer).
+    # `confidence` is the dominant model's self-reported 0.0-1.0 score for
+    # this utterance; `source` identifies which subsystem produced it
+    # (e.g. "freestyle_llm", "qa_llm", "small_talk_llm", "router_llm").
+    # The route layer uses these for low-confidence routing and structured
+    # logging; backend/app/schemas/utterance.py does NOT carry them.
+    confidence: float | None = None
+    source: str | None = None

--- a/backend/tests/unit/test_clarification_loop.py
+++ b/backend/tests/unit/test_clarification_loop.py
@@ -18,6 +18,7 @@ from fastapi.testclient import TestClient
 from app.deps import get_db, get_gemini_client, get_tts
 from app.main import app
 from gemini_client import Intent, ParsedIngredient, UtteranceResponse
+from gemini_client.schemas import Disambiguation
 
 
 # ---------------------------------------------------------------------------
@@ -567,5 +568,138 @@ class TestSessionLifecycle:
 
             # Turn 2 belongs to session B; pending_clarification must be None
             assert mock_gemini.captured[1]["pending_clarification"] is None
+        finally:
+            self._clear()
+
+
+# ---------------------------------------------------------------------------
+# Disambiguation flows — the second shape of clarification
+# ---------------------------------------------------------------------------
+
+_ROUTER_DISAMBIG = UtteranceResponse(
+    intent=Intent.acknowledgment,
+    ack="Did you mean to add an ingredient or ask a cooking question?",
+    items=None,
+    confidence=0.55,
+    source="router_llm",
+    disambiguation=Disambiguation(kind="router", best="freestyle", second="qa"),
+)
+
+_AFTER_ROUTER_PICK = UtteranceResponse(
+    intent=Intent.add_ingredient,
+    ack="Got it, two cloves of garlic.",
+    items=[ParsedIngredient(name="garlic", qty=2.0, unit="clove", raw_phrase="two cloves of garlic")],
+    confidence=0.95,
+    source="freestyle_llm",
+)
+
+_EXTRACTION_DISAMBIG = UtteranceResponse(
+    intent=Intent.add_ingredient,
+    ack="Did you mean heavy cream or sour cream?",
+    items=[],
+    confidence=0.6,
+    source="freestyle_llm",
+    disambiguation=Disambiguation(kind="extraction", best="heavy cream", second="sour cream"),
+)
+
+_AFTER_EXTRACTION_PICK = UtteranceResponse(
+    intent=Intent.add_ingredient,
+    ack="Got it, half a cup of heavy cream.",
+    items=[ParsedIngredient(name="heavy cream", qty=0.5, unit="cup", raw_phrase="heavy cream")],
+    confidence=0.92,
+    source="freestyle_llm",
+)
+
+
+class TestRouterDisambig:
+    """Router-level disambiguation: low-confidence classification → ask the user."""
+
+    def _overrides(self, fake_tts, mock_gemini, fake_db):
+        app.dependency_overrides[get_gemini_client] = lambda: mock_gemini
+        app.dependency_overrides[get_tts] = lambda: fake_tts
+        app.dependency_overrides[get_db] = lambda: fake_db
+
+    def _clear(self):
+        app.dependency_overrides.clear()
+
+    def test_router_disambig_two_turn_loop(self):
+        """Turn 1: ambiguous utterance → router disambig question + awaiting_clarification.
+        Turn 2: user picks; LLM receives pending_clarification=None (re-classify fresh).
+        Pending is cleared after a normal handler response.
+        """
+        fake_tts = _FakeTTS()
+        mock_gemini = _make_sequential_gemini(_ROUTER_DISAMBIG, _AFTER_ROUTER_PICK)
+        fake_db = _FakeDB()
+
+        self._overrides(fake_tts, mock_gemini, fake_db)
+        try:
+            with TestClient(app) as c:
+                session_id = _new_session(c)
+
+                body1 = _post(c, session_id)
+                assert body1["awaiting_clarification"] is True
+                assert fake_tts.last_stashed == "Did you mean to add an ingredient or ask a cooking question?"
+
+                # Sentinel was persisted with the right prefix
+                stored = fake_db._tables["recipes"][0]["pending_clarification"]
+                assert stored is not None
+                assert stored.startswith("ROUTER_DISAMBIG:")
+                assert "freestyle" in stored and "qa" in stored
+
+                body2 = _post(c, session_id)
+                assert body2["awaiting_clarification"] is False
+                assert body2["intent"] == "add_ingredient"
+
+            # Turn-2 LLM call must NOT receive a pending hint — router needs to
+            # re-classify the user's choice from scratch.
+            assert mock_gemini.captured[1]["pending_clarification"] is None
+        finally:
+            self._clear()
+
+
+class TestExtractionDisambig:
+    """Extraction-level disambiguation: ambiguous ingredient name → ask the user."""
+
+    def _overrides(self, fake_tts, mock_gemini, fake_db):
+        app.dependency_overrides[get_gemini_client] = lambda: mock_gemini
+        app.dependency_overrides[get_tts] = lambda: fake_tts
+        app.dependency_overrides[get_db] = lambda: fake_db
+
+    def _clear(self):
+        app.dependency_overrides.clear()
+
+    def test_extraction_disambig_two_turn_loop(self):
+        """Turn 1: 'cream' → freestyle disambig. Turn 2: user picks; freestyle prompt
+        sees the question text and parses the choice; pending cleared."""
+        fake_tts = _FakeTTS()
+        mock_gemini = _make_sequential_gemini(_EXTRACTION_DISAMBIG, _AFTER_EXTRACTION_PICK)
+        fake_db = _FakeDB()
+
+        self._overrides(fake_tts, mock_gemini, fake_db)
+        try:
+            with TestClient(app) as c:
+                session_id = _new_session(c)
+
+                body1 = _post(c, session_id)
+                assert body1["awaiting_clarification"] is True
+                assert fake_tts.last_stashed == "Did you mean heavy cream or sour cream?"
+
+                stored = fake_db._tables["recipes"][0]["pending_clarification"]
+                assert stored is not None
+                assert stored.startswith("EXTRACTION_DISAMBIG:")
+                assert "heavy cream" in stored and "sour cream" in stored
+
+                body2 = _post(c, session_id)
+                assert body2["awaiting_clarification"] is False
+                assert body2["intent"] == "add_ingredient"
+
+                # Heavy cream landed in the session
+                names = [i["name"] for i in body2["current_ingredients"]]
+                assert "heavy cream" in names
+
+            # Turn 2: LLM receives the question text (display only), NEVER the sentinel
+            turn2_pending = mock_gemini.captured[1]["pending_clarification"]
+            assert turn2_pending == "Did you mean heavy cream or sour cream?"
+            assert "EXTRACTION_DISAMBIG:" not in (turn2_pending or "")
         finally:
             self._clear()

--- a/backend/tests/unit/test_clarification_loop.py
+++ b/backend/tests/unit/test_clarification_loop.py
@@ -650,6 +650,9 @@ class TestRouterDisambig:
                 assert body2["awaiting_clarification"] is False
                 assert body2["intent"] == "add_ingredient"
 
+                # Pending sentinel was cleared, not just downgraded
+                assert fake_db._tables["recipes"][0]["pending_clarification"] is None
+
             # Turn-2 LLM call must NOT receive a pending hint — router needs to
             # re-classify the user's choice from scratch.
             assert mock_gemini.captured[1]["pending_clarification"] is None


### PR DESCRIPTION
## What

Adds per-call confidence scoring to the LLM router and LLM-backed handlers (`freestyle`, `qa`, `small_talk`). Low-confidence router classifications now route to a disambiguation question (\"Did you mean to add an ingredient or ask a cooking question?\") instead of guessing — gated by thresholds in a new `gemini_client/config.py`. Eval harness gains a calibration report + `eval_results.json` sidecar; `suggest_thresholds.py` reads that and recommends F1-max thresholds. Mobile boundary unchanged.

## Why

Issue #?? (priority:high reliability). For users tracking macros daily, the model should ask before guessing on ambiguous utterances. The clarification machinery already existed for missing-quantity (\"How much garlic?\"); this adds a second shape (\"Did you mean A or B?\") on the same Supabase column with two new sentinel prefixes (`ROUTER_DISAMBIG:`, `EXTRACTION_DISAMBIG:`) — no migration. Plan: \`docs/notes/2026-05-02-upgrade-classification-prompt.md\`.

Production model unchanged (\`llama-3.1-8b-instant\`). Eval harness can target a local Ollama via \`LLM_BASE_URL\` / \`LLM_API_KEY\` / \`LLM_MODEL\` env-var overrides for fast iteration without burning Groq tokens.

## How to test

\`\`\`bash
cd backend

# Unit + smoke
uv run pytest tests/unit/ tests/smoke/ -x

# Local iteration (Ollama, no API tokens):
ollama pull llama3:8b
LLM_BASE_URL=http://localhost:11434 \\
LLM_API_KEY=ollama \\
LLM_MODEL=llama3:8b \\
LLM_TOOLS_DISABLED=1 \\
EVAL_RATE_LIMIT_DELAY=0 \\
uv run pytest gemini_client/evals/ -q --tb=short

# Threshold analysis
uv run python -m gemini_client.evals.suggest_thresholds
\`\`\`

**Smoke test:** ✅ \`tests/smoke/\` passes.
**Unit tests:** ✅ 42 pass, including 2 new disambiguation-loop tests in \`test_clarification_loop.py\`.
**Subagents:** \`code-reviewer\` returned \`pass\`; \`integration-checker\` returned \`consistent: true\` (mobile + app-layer wire format unchanged).

**Eval status (Groq, llama-3.1-8b-instant):**

A full Groq verification run surfaced one real prompt regression: the original extraction-level disambiguation prompt section caused the model to emit \`items: []\` on confident, unambiguous cases. That prompt section was rolled back in \`d862d01\` — the schema field, handler stamp, route-layer sentinel encoding, and unit tests are kept so a follow-up PR can re-introduce the prompt with sharper gating. Targeted re-run on the 5 regression cases confirms recovery; \`noqty_add_olive_oil\` still misses but stays within the existing \`add_ingredient_no_qty\` 0.800 baseline. **A clean full Groq run is the merge gate.**

## Checklist

- [x] Tests added/updated and passing (\`uv run pytest tests/unit/\`)
- [x] Smoke test green: \`cd backend && uv run pytest tests/smoke/ -x\`
- [x] No \`.env\` in diff; \`.env.example\` updated with the 6 new optional env vars
- [x] API contract unchanged — \`backend/app/schemas/utterance.py\` and \`mobile/src/api/types.ts\` are byte-identical to \`main\` (verified by \`integration-checker\` + empty \`git diff\`); \`gemini_client.UtteranceResponse\` gained \`confidence\` / \`source\` / \`disambiguation\` as internal-only fields the route layer consumes but does not propagate
- [x] Rebased on \`main\` (not merged)
- [ ] \`CLAUDE.md\` updated if architecture changed (unchanged — \`gemini_client\` module structure preserved)
- [x] Per the updated partner-workflow rule (memory: \`feedback_branching_discipline\`), either dev may edit \`backend/gemini_client/\`; branch prefix identifies the driver, not the owner. Template line 22 is stale.

## Out of scope

- Model swap (\`llama-3.1-8b-instant\` stays).
- Polymorphic SDK / provider abstraction (env-var overrides on existing Groq SDK only; one tiny httpx transport rewrites \`/openai/v1\` → \`/v1\` for Ollama compatibility).
- QA / small_talk disambiguation routing — confidence is recorded for the calibration report only.
- Logprobs-based confidence — self-reported via prompts; can revisit if calibration is poor.
- Mobile UI for confidence — stays internal.
- Loop escalation after N retries.
- Three-way disambiguation (top-2 only).
- \`baseline_scores.json\` bump.